### PR TITLE
[Feat] 내 일정 목록

### DIFF
--- a/frontend/src/api/schedule.ts
+++ b/frontend/src/api/schedule.ts
@@ -90,7 +90,8 @@ export async function deleteSchedule(
 
 // 나의 일정 목록 조회
 export async function getMySchedules(
-  query?: { startDate?: string; endDate?: string }
+  query?: { startDate?: string; endDate?: string },
+  signal?: AbortSignal
 ): Promise<components["schemas"]["RsDataListScheduleDto"]> {
   let url = `${BASE_URL}/api/v1/schedules/me`;
   if (query) {
@@ -100,6 +101,9 @@ export async function getMySchedules(
     url += `?${params.toString()}`;
   }
 
-  const res = await fetch(url);
-  return handleResponse(res);
+  const res = await fetch(url, {
+    method: "GET",
+    signal,
+  });
+  return handleResponse<components["schemas"]["RsDataListScheduleWithClubDto"]>(res);
 }

--- a/frontend/src/app/schedule/modals/ScheduleModal.tsx
+++ b/frontend/src/app/schedule/modals/ScheduleModal.tsx
@@ -11,12 +11,14 @@ interface ScheduleModalProps {
   showModal: boolean;
   selectedScheduleId: number | null;
   onClose: (shouldRefresh: boolean, action?: 'modify' | 'goToCheckList' | 'createCheckList', targetId?: number) => void;
+  isReadOnly?: boolean;
 }
 
 export default function ScheduleModal ({
   showModal,
   selectedScheduleId,
-  onClose
+  onClose,
+  isReadOnly
 }: ScheduleModalProps ) {
   const [schedule, setSchedule] = useState<ScheduleDetailDto | null | undefined>(null);
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
@@ -157,21 +159,25 @@ export default function ScheduleModal ({
 
               {/* 우측 버튼 그룹 */}
               <div className="flex space-x-2">
-                <button
-                  type="button"
-                  onClick={handleModifyClick}
-                  disabled={isDeleting}
-                  className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 transition-colors disabled:opacity-50"
-                >
-                  수정
-                </button>
-                <button
-                  onClick={handleDelete}
-                  disabled={isDeleting}
-                  className="px-4 py-2 bg-red-400 text-white rounded-md hover:bg-red-700 transition-colors disabled:opacity-50"
-                >
-                  {isDeleting ? '삭제 중...' : '삭제'}
-                </button>
+                {!isReadOnly && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={handleModifyClick}
+                      disabled={isDeleting}
+                      className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 transition-colors disabled:opacity-50"
+                    >
+                      수정
+                    </button>
+                    <button
+                      onClick={handleDelete}
+                      disabled={isDeleting}
+                      className="px-4 py-2 bg-red-400 text-white rounded-md hover:bg-red-700 transition-colors disabled:opacity-50"
+                    >
+                      {isDeleting ? '삭제 중...' : '삭제'}
+                    </button>
+                  </>
+                )}
                 <button
                   onClick={handleCloseClick}
                   disabled={isDeleting}

--- a/frontend/src/app/schedule/modals/ScheduleModal.tsx
+++ b/frontend/src/app/schedule/modals/ScheduleModal.tsx
@@ -42,8 +42,9 @@ export default function ScheduleModal ({
       // 일정 세팅
       setSchedule(data.data);
     } catch (e: any) {
-      if (e instanceof DOMException && e.name === 'AbortError') return; 
-      
+      // 요청 취소는 무시
+      if (e instanceof Error && e.name === 'AbortError') return;
+      // 에러 처리
       const msg = e instanceof Error ? e.message : '일정 상세 불러오기 실패';
       setError(msg);
       toast.error(msg);

--- a/frontend/src/app/schedule/my/page.tsx
+++ b/frontend/src/app/schedule/my/page.tsx
@@ -1,0 +1,79 @@
+// app/schedule/my/MySchedulePage.tsx
+
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import toast from 'react-hot-toast';
+
+import FullCalendar from '@fullcalendar/react';
+import { EventClickArg } from '@fullcalendar/core';
+
+import { getMySchedules } from "@/api/schedule";
+import { useSchedules } from '@/hooks/useSchedules';
+import { extractDateFromISO } from '@/lib/formatDate';
+import Calendar from '@/components/domain/schedule/Calender';
+import ScheduleModal from '@/app/schedule/modals/ScheduleModal';
+
+import '@/lib/fullcalendar.css';
+
+export default function MyScheduleListPage() {
+  const calendarRef = useRef<FullCalendar>(null);
+  const [selectedScheduleId, setSelectedScheduleId] = useState<number | null>(null);
+  const [showModal, setShowModal] = useState<boolean>(false);
+
+  // 커스텀 훅 - 일정 dto, 나의 일정 목록 조회 fetch 넘김
+  const { events, fetchSchedules } = useSchedules(getMySchedules);
+
+  // 최초 조회
+  useEffect(() => {
+    // 캘린더 API를 통해 현재 뷰의 날짜 범위를 가져와서 데이터 조회
+    if (calendarRef.current) {
+      const calendarApi = calendarRef.current.getApi();
+      const view = calendarApi.view;
+      const startDate = extractDateFromISO(view.activeStart.toISOString());
+      const endDate = extractDateFromISO(view.activeEnd.toISOString());
+      fetchSchedules({ startDate, endDate });
+    }
+  }, [fetchSchedules]);
+
+
+  // 캘린더 날짜가 변경될 때마다(이전, 다음 버튼 등) 일정 목록 API 재호출
+  const handleDatesSet = useCallback((arg: any) => {
+    const startDate = extractDateFromISO(arg.startStr);
+    const endDate = extractDateFromISO(arg.endStr);
+    fetchSchedules({ startDate, endDate });
+  }, [fetchSchedules]);
+
+  // 일정 클릭 시 상세 모달만 열기
+  const handleEventClick = (clickInfo: EventClickArg) => {
+    setSelectedScheduleId(Number(clickInfo.event.id));
+    setShowModal(true);
+  };
+  
+  // 모달 닫기
+  const handleCloseModal = useCallback(() => {
+    setShowModal(false);
+    setSelectedScheduleId(null);
+  }, []);
+
+  return (
+    <div className='flex flex-col lg:flex-row min-h-screen bg-gray-100 font-sans'>
+      <div className='flex-1 p-4 lg:p-6'>
+        <Calendar 
+          ref={calendarRef}
+          events={events} 
+          handleDatesSet={handleDatesSet} 
+          handleEventClick={handleEventClick}
+        />
+        {showModal && (
+          <ScheduleModal
+            showModal={showModal}
+            selectedScheduleId={selectedScheduleId}
+            onClose={handleCloseModal}
+            isReadOnly={true}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/schedule/my/page.tsx
+++ b/frontend/src/app/schedule/my/page.tsx
@@ -1,12 +1,9 @@
-// app/schedule/my/MySchedulePage.tsx
-
 'use client';
 
 import { useState, useCallback, useRef, useEffect } from 'react';
-import toast from 'react-hot-toast';
 
 import FullCalendar from '@fullcalendar/react';
-import { EventClickArg } from '@fullcalendar/core';
+import { EventClickArg, DatesSetArg } from '@fullcalendar/core';
 
 import { getMySchedules } from "@/api/schedule";
 import { useSchedules } from '@/hooks/useSchedules';
@@ -38,7 +35,7 @@ export default function MyScheduleListPage() {
 
 
   // 캘린더 날짜가 변경될 때마다(이전, 다음 버튼 등) 일정 목록 API 재호출
-  const handleDatesSet = useCallback((arg: any) => {
+  const handleDatesSet = useCallback((arg: DatesSetArg) => {
     const startDate = extractDateFromISO(arg.startStr);
     const endDate = extractDateFromISO(arg.endStr);
     fetchSchedules({ startDate, endDate });

--- a/frontend/src/app/schedule/page.tsx
+++ b/frontend/src/app/schedule/page.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'next/navigation';
 import { useState, useCallback, useRef, useEffect } from 'react';
 import toast from 'react-hot-toast';
 
-import { EventClickArg, DateSelectArg } from '@fullcalendar/core';
+import { EventClickArg, DateSelectArg, DatesSetArg } from '@fullcalendar/core';
 import FullCalendar from '@fullcalendar/react';
 
 import { getClubSchedules } from "@/api/schedule";
@@ -49,7 +49,7 @@ export default function ScheduleListPage() {
   }, [fetchSchedules]);
 
   // 캘린더 날짜가 변경될 때마다(이전, 다음 버튼 등) 일정 목록 API 재호출
-  const handleDatesSet = useCallback((arg: any) => {
+  const handleDatesSet = useCallback((arg: DatesSetArg) => {
     const startDate = extractDateFromISO(arg.startStr);
     const endDate = extractDateFromISO(arg.endStr);
     fetchSchedules({ startDate, endDate });

--- a/frontend/src/app/schedule/page.tsx
+++ b/frontend/src/app/schedule/page.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { useParams } from 'next/navigation';
-import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import toast from 'react-hot-toast';
 
-import { EventInput, EventClickArg, DateSelectArg } from '@fullcalendar/core';
+import { EventClickArg, DateSelectArg } from '@fullcalendar/core';
 import FullCalendar from '@fullcalendar/react';
 
-import type { components } from "@/types/backend/apiV1/schema";
 import { getClubSchedules } from "@/api/schedule";
+import { useSchedules } from '@/hooks/useSchedules';
 import { extractDateFromISO } from '@/lib/formatDate';
 import Calendar from '@/components/domain/schedule/Calender';
 import ScheduleModal from '@/app/schedule/modals/ScheduleModal';
@@ -24,7 +24,6 @@ export default function ScheduleListPage() {
 
   // 캘린더 처리
   const calendarRef = useRef<FullCalendar>(null);
-  const [events, setEvents] = useState<EventInput[]>([]); 
   const [selectedDateInfo, setSelectedDateInfo] = useState<DateSelectArg | null>(null);
   const [selectedScheduleId, setSelectedScheduleId] = useState<number | null>(null);
 
@@ -32,67 +31,28 @@ export default function ScheduleListPage() {
   const [showModal, setShowModal] = useState<boolean>(false);
   const [modalType, setModalType] = useState<'edit' | 'detail' | null>(null);
 
-  // API 호출 취소를 위한 AbortController
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  // 커스텀 훅 - 일정 dto, 모임의 일정 목록 조회 fetch 넘김
+  const { events, fetchSchedules } = useSchedules((params, signal) => 
+    getClubSchedules(clubId, params, signal)
+  );
 
-  // ScheduleDto를 FullCalendar Event 객체로 변환
-  const convertSchedulesToEvents = (
-    schedules: components["schemas"]["ScheduleDto"][]
-  ) => {
-    return schedules.map(schedule => ({
-      id: schedule.id !== undefined ? String(schedule.id) : undefined,
-      title: schedule.title || '제목 없음',
-      start: schedule.startDate || new Date().toISOString(),
-      end: schedule.endDate,
-      allDay: (schedule.startDate?.length || 0) <= 10 && (schedule.endDate?.length || 0) <= 10,
-      color: '#6366F1', // bg-indigo-500
-      textColor: '#FFFFFF'
-    }));
-  };
-  
-  // 컴포넌트 사라질 때 요청 취소
+  // 최초 조회
   useEffect(() => {
-    return () => {
-      abortControllerRef.current?.abort();
-    };
-  }, []);
-
-  const fetchSchedules = useCallback(async (startDate?: string, endDate?: string) => {
-    if (!clubId) {
-      setError('유효하지 않은 모임입니다.');
-      return;
+    // 캘린더 API를 통해 현재 뷰의 날짜 범위를 가져와서 데이터 조회
+    if (calendarRef.current) {
+      const calendarApi = calendarRef.current.getApi();
+      const view = calendarApi.view;
+      const startDate = extractDateFromISO(view.activeStart.toISOString());
+      const endDate = extractDateFromISO(view.activeEnd.toISOString());
+      fetchSchedules({ startDate, endDate });
     }
-    // 이전 요청 있으면 취소
-    abortControllerRef.current?.abort();
-    const controller = new AbortController();
-    abortControllerRef.current = controller;
-
-    setError(null);
-
-    try {
-      // 일정 목록 조회
-      const data = await getClubSchedules(Number(clubId), { startDate, endDate }, controller.signal);
-      // 일정 목록 세팅
-      const events = convertSchedulesToEvents(data.data ?? []);
-
-      // 캘린더 이벤트 저장
-      setEvents(events);
-    } catch (e) {
-      // 요청 취소는 무시
-      if (e instanceof Error && e.message.includes('aborted')) return; 
-      // 에러 처리
-      const msg = e instanceof Error ? e.message : '일정 불러오기 실패';
-      setError(msg);
-      toast.error(msg);
-    }
-  }, [clubId]);
+  }, [fetchSchedules]);
 
   // 캘린더 날짜가 변경될 때마다(이전, 다음 버튼 등) 일정 목록 API 재호출
   const handleDatesSet = useCallback((arg: any) => {
     const startDate = extractDateFromISO(arg.startStr);
     const endDate = extractDateFromISO(arg.endStr);
-    fetchSchedules(startDate, endDate);
+    fetchSchedules({ startDate, endDate });
   }, [fetchSchedules]);
 
   // Date UI(일) 클릭 시 일정 생성/수정정 모달
@@ -111,8 +71,24 @@ export default function ScheduleListPage() {
     setShowModal(true);
   };
 
+  // 일정 생성/삭제 후 캘린더를 최신화
+  const refreshCalendar = async () => {
+    if (calendarRef.current) {
+      const calendarApi = calendarRef.current.getApi();
+      const view = calendarApi.view;
+      const startDate = extractDateFromISO(view.activeStart.toISOString());
+      const endDate = extractDateFromISO(view.activeEnd.toISOString());
+      // 일정 목록 재조회
+      await fetchSchedules({ startDate, endDate });
+    }
+  };
+
   // 모달 닫기
-  const handleCloseModal = (shouldRefresh: boolean, action?: 'modify' | 'goToCheckList' | 'createCheckList', targetId?: number) => {
+  const handleCloseModal = useCallback((
+    shouldRefresh: boolean, 
+    action?: 'modify' | 'goToCheckList' | 'createCheckList', 
+    targetId?: number
+  ) => {
     setShowModal(false);
     setSelectedDateInfo(null);
     setModalType(null);
@@ -135,19 +111,7 @@ export default function ScheduleListPage() {
     if (shouldRefresh) {
       refreshCalendar();
     }
-  };
-  
-  // 일정 생성/삭제 후 캘린더를 최신화
-  const refreshCalendar = async () => {
-    if (calendarRef.current) {
-      const calendarApi = calendarRef.current.getApi();
-      const view = calendarApi.view;
-      const startDate = extractDateFromISO(view.activeStart.toISOString());
-      const endDate = extractDateFromISO(view.activeEnd.toISOString());
-      // 일정 목록 재조회
-      await fetchSchedules(startDate, endDate);
-    }
-  };
+  }, [refreshCalendar]);
 
   return (
     <div className='flex flex-col lg:flex-row min-h-screen bg-gray-100 font-sans'>

--- a/frontend/src/components/domain/schedule/Calender.tsx
+++ b/frontend/src/components/domain/schedule/Calender.tsx
@@ -12,7 +12,7 @@ interface CalendarProps {
   events: any[];
   handleDatesSet: (arg: any) => void;
   handleEventClick: (clickInfo: EventClickArg) => void; 
-  handleDateSelect: (selectInfo: DateSelectArg) => void;
+  handleDateSelect?: (selectInfo: DateSelectArg) => void;
 }
 
 const Calendar = forwardRef<FullCalendar, CalendarProps>(({

--- a/frontend/src/constants/colors.tsx
+++ b/frontend/src/constants/colors.tsx
@@ -5,12 +5,36 @@ export const COLOR_YELLOW = "#F8F3CE";
 export const COLOR_WHITE = "#FFFFFF";
 export const COLOR_BLACK = "#000000";
 
+// 파스텔 색상
+export const COLOR_INDIGO = '#A1C6F8';
+export const COLOR_SKY_BLUE_PASTEL = '#81D4FA';
+export const COLOR_MINT_PASTEL = '#80CBC4';
+export const COLOR_APRICOT_PASTEL = '#FFCC80';
+export const COLOR_LAVENDER_PASTEL = '#B39DDB';
+export const COLOR_PINK_PASTEL = '#EF9A9A';
+export const COLOR_LIME_PASTEL = '#C5E1A5';
+export const COLOR_BEIGE_PASTEL = '#A1887F';
+export const COLOR_GRAY_PASTEL = '#B0BEC5';
+
 // 색상들을 객체로 묶어서 export 할 수도 있습니다.
 export const COLORS = {
-    brown: COLOR_BROWN,
-    gray: COLOR_GRAY,
-    beige: COLOR_BEIGE,
-    yellow: COLOR_YELLOW,
-    white: COLOR_WHITE,
-    black: COLOR_BLACK
+	brown: COLOR_BROWN,
+	gray: COLOR_GRAY,
+	beige: COLOR_BEIGE,
+	yellow: COLOR_YELLOW,
+	white: COLOR_WHITE,
+	black: COLOR_BLACK
 };
+
+// 일정에 사용할 색상 팔레트
+export const SCHEDULE_COLORS = [
+	COLOR_INDIGO,
+	COLOR_SKY_BLUE_PASTEL,
+	COLOR_MINT_PASTEL,
+	COLOR_APRICOT_PASTEL,
+	COLOR_LAVENDER_PASTEL,
+	COLOR_PINK_PASTEL,
+	COLOR_LIME_PASTEL,
+	COLOR_BEIGE_PASTEL,
+	COLOR_GRAY_PASTEL
+];

--- a/frontend/src/hooks/useSchedules.ts
+++ b/frontend/src/hooks/useSchedules.ts
@@ -9,6 +9,7 @@ import { EventInput } from '@fullcalendar/core';
 type ScheduleDto = components["schemas"]["ScheduleDto"];
 type ScheduleWithClubDto = components["schemas"]["ScheduleWithClubDto"];
 type UnionScheduleDto = ScheduleDto & Partial<ScheduleWithClubDto>;
+import { SCHEDULE_COLORS, COLOR_INDIGO } from '@/constants/colors';
 
 // fetch params
 type FetchParams = {
@@ -25,6 +26,11 @@ export const useSchedules = <T extends UnionScheduleDto>(
   const [error, setError] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
+  // 모임마다 다른 색상의 bar
+  const generateColor = (id: number) => {
+    return SCHEDULE_COLORS[id % SCHEDULE_COLORS.length];
+  };
+
   // ScheduleDto/ScheduleWithClubDto를 FullCalendar Event 객체로 변환
   const convertSchedulesToEvents = (schedules: T[]) => {
     return schedules.map(schedule => {
@@ -32,13 +38,18 @@ export const useSchedules = <T extends UnionScheduleDto>(
       const hasClubInfo = (schedule as ScheduleWithClubDto).clubName !== undefined;
       const titlePrefix = hasClubInfo && (schedule as ScheduleWithClubDto).clubName ? `[${(schedule as ScheduleWithClubDto).clubName}] ` : '';
 
+      const color = hasClubInfo && (schedule as ScheduleWithClubDto).clubId 
+        ? generateColor((schedule as ScheduleWithClubDto).clubId!) 
+        : COLOR_INDIGO;
+      
       // 일정 정보 세팅
       return {
         id: schedule.id !== undefined ? String(schedule.id) : undefined,
         title: titlePrefix + (schedule.title || '제목 없음'),
         start: schedule.startDate || new Date().toISOString(),
         end: schedule.endDate,
-        allDay: (schedule.startDate?.length || 0) <= 10 && (schedule.endDate?.length || 0) <= 10
+        allDay: (schedule.startDate?.length || 0) <= 10 && (schedule.endDate?.length || 0) <= 10,
+        color
       };
     });
   };

--- a/frontend/src/hooks/useSchedules.ts
+++ b/frontend/src/hooks/useSchedules.ts
@@ -1,0 +1,86 @@
+// hooks/useSchedules.ts
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import toast from 'react-hot-toast';
+
+import type { components } from "@/types/backend/apiV1/schema";
+import { EventInput } from '@fullcalendar/core';
+
+type ScheduleDto = components["schemas"]["ScheduleDto"];
+type ScheduleWithClubDto = components["schemas"]["ScheduleWithClubDto"];
+type UnionScheduleDto = ScheduleDto & Partial<ScheduleWithClubDto>;
+
+// fetch params
+type FetchParams = {
+  startDate?: string;
+  endDate?: string;
+  clubId?: number;
+};
+
+// 일정 목록 공통 훅
+export const useSchedules = <T extends UnionScheduleDto>(
+  fetchApi: (params?: FetchParams, signal?: AbortSignal) => Promise<{ data?: T[] | null | undefined }>
+) => {
+  const [events, setEvents] = useState<EventInput[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  // ScheduleDto/ScheduleWithClubDto를 FullCalendar Event 객체로 변환
+  const convertSchedulesToEvents = (schedules: T[]) => {
+    return schedules.map(schedule => {
+      // 나의 일정 목록은 클럽명 포함
+      const hasClubInfo = (schedule as ScheduleWithClubDto).clubName !== undefined;
+      const titlePrefix = hasClubInfo && (schedule as ScheduleWithClubDto).clubName ? `[${(schedule as ScheduleWithClubDto).clubName}] ` : '';
+
+      // 일정 정보 세팅
+      return {
+        id: schedule.id !== undefined ? String(schedule.id) : undefined,
+        title: titlePrefix + (schedule.title || '제목 없음'),
+        start: schedule.startDate || new Date().toISOString(),
+        end: schedule.endDate,
+        allDay: (schedule.startDate?.length || 0) <= 10 && (schedule.endDate?.length || 0) <= 10
+      };
+    });
+  };
+
+  // 일정 목록 조회
+  const fetchSchedules = useCallback(async (params: FetchParams) => {
+    // 이전 요청 있으면 취소
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    setError(null);
+
+    try {
+      // 모임의 일정 목록은 모임 아이디 전달 받음(필수)
+      if ('clubId' in params) {
+        setError('유효하지 않은 모임입니다.');
+        return;
+      }
+      // 일정 목록 조회
+      const data = await fetchApi(params, controller.signal);
+
+      // 일정 목록 세팅
+      const events = convertSchedulesToEvents(data.data ?? []);
+      // 캘린더 이벤트 저장
+      setEvents(events);
+    } catch (e) {
+      // 요청 취소는 무시
+      if (e instanceof Error && e.message.includes('aborted')) return;
+      // 에러 처리
+      const msg = e instanceof Error ? e.message : '일정 불러오기 실패';
+      setError(msg);
+      toast.error(msg);
+    }
+  }, [fetchApi, convertSchedulesToEvents]);
+
+  // 컴포넌트 사라질 때 요청 취소
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
+
+  return { events, error, fetchSchedules };
+};

--- a/frontend/src/hooks/useSchedules.ts
+++ b/frontend/src/hooks/useSchedules.ts
@@ -65,7 +65,7 @@ export const useSchedules = <T extends UnionScheduleDto>(
 
     try {
       // 모임의 일정 목록은 모임 아이디 전달 받음(필수)
-      if ('clubId' in params) {
+      if ('clubId' in params && !params.clubId) {
         setError('유효하지 않은 모임입니다.');
         return;
       }
@@ -78,13 +78,13 @@ export const useSchedules = <T extends UnionScheduleDto>(
       setEvents(events);
     } catch (e) {
       // 요청 취소는 무시
-      if (e instanceof Error && e.message.includes('aborted')) return;
+      if (e instanceof Error && e.name === 'AbortError') return;
       // 에러 처리
       const msg = e instanceof Error ? e.message : '일정 불러오기 실패';
       setError(msg);
       toast.error(msg);
     }
-  }, [fetchApi, convertSchedulesToEvents]);
+  }, [fetchApi]);
 
   // 컴포넌트 사라질 때 요청 취소
   useEffect(() => {

--- a/frontend/src/lib/fullcalendar.css
+++ b/frontend/src/lib/fullcalendar.css
@@ -13,9 +13,9 @@
   }
   
   /* FullCalendar 일정 배경 색상 변경 */
-  .fc .fc-event {
+  /* .fc .fc-event {
     @apply !bg-indigo-500;
-  }
+  } */
   
   /* 마우스 오버 시 일정 스타일 변경 */
   .fc .fc-event:hover {

--- a/frontend/src/lib/fullcalendar.css
+++ b/frontend/src/lib/fullcalendar.css
@@ -12,11 +12,6 @@
     @apply text-gray-600;
   }
   
-  /* FullCalendar 일정 배경 색상 변경 */
-  /* .fc .fc-event {
-    @apply !bg-indigo-500;
-  } */
-  
   /* 마우스 오버 시 일정 스타일 변경 */
   .fc .fc-event:hover {
     @apply !bg-indigo-900;

--- a/frontend/src/lib/fullcalendar.css
+++ b/frontend/src/lib/fullcalendar.css
@@ -14,17 +14,17 @@
   
   /* FullCalendar 일정 배경 색상 변경 */
   .fc .fc-event {
-    @apply bg-indigo-500;
+    @apply !bg-indigo-500;
   }
   
   /* 마우스 오버 시 일정 스타일 변경 */
   .fc .fc-event:hover {
-    @apply bg-indigo-900;
-    @apply text-gray-600;
+    @apply !bg-indigo-900;
+    @apply !text-gray-600;
   }
 
   /* --- 모든 일정의 글씨 색상 --- */
   .fc .fc-timegrid {
-    @apply text-gray-600;
+    @apply !text-gray-600;
   }
 }


### PR DESCRIPTION
## 📢 기능 설명
- 내 일정 목록 조회
- 일정 목록 공통 훅
- 모임별 다른 색상의 일정바

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #18 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 내 일정 전용 캘린더 페이지가 추가되어, 사용자가 자신의 일정을 달력 형태로 확인할 수 있습니다.
  * 일정 모달에 읽기 전용 모드가 도입되어, 수정 및 삭제 버튼이 숨겨집니다.
  * 파스텔 계열의 일정 색상 팔레트가 추가되었습니다.

* **리팩터**
  * 일정 데이터 조회 및 변환 로직이 커스텀 훅으로 통합되어 코드 구조가 간소화되었습니다.
  * 일정 캘린더 컴포넌트의 날짜 선택 핸들러가 선택적으로 적용될 수 있도록 개선되었습니다.
  * 일정 조회 API 호출에 취소 신호(AbortSignal) 지원이 추가되어 네트워크 요청 관리가 향상되었습니다.
  * 일정 리스트 페이지에서 일정 조회 및 상태 관리가 커스텀 훅을 활용하도록 리팩터링되었습니다.

* **스타일**
  * 일정 이벤트 및 캘린더의 색상과 호버 스타일이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->