### PR TITLE
 [design] 모임 멤버 관리 페이지 구성

### DIFF
--- a/frontend/src/api/clubMember.tsx
+++ b/frontend/src/api/clubMember.tsx
@@ -9,9 +9,10 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
 
 // 멤버 목록 조회
 export const getClubMembers = async (clubId: string): Promise<MemberInfo[]> => {
+
     const response = await fetch(`${API_URL}/api/v1/clubs/${clubId}/members`, {
         method: 'GET',
-        credentials: 'include',
+        credentials: 'include', // 쿠키를 포함하여 요청
     });
     if (!response.ok) {
         const errorData = await response.json();

--- a/frontend/src/api/clubMember.tsx
+++ b/frontend/src/api/clubMember.tsx
@@ -28,7 +28,10 @@ export const approveApplication = async (clubId: string, memberId: number) => {
         method: 'PATCH',
         credentials: 'include',
     });
-    if (!response.ok) throw new Error('가입 승인에 실패했습니다.');
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || '가입 승인에 실패했습니다.');
+    }
 };
 
 // 가입 신청 거절
@@ -37,7 +40,10 @@ export const rejectApplication = async (clubId: string, memberId: number) => {
         method: 'DELETE',
         credentials: 'include',
     });
-    if (!response.ok) throw new Error('가입 거절에 실패했습니다.');
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || '가입 거절에 실패했습니다.');
+    }
 };
 
 // 멤버 역할 변경
@@ -48,7 +54,9 @@ export const changeMemberRole = async (clubId: string, memberId: number, role: '
         body: JSON.stringify({ role }),
         credentials: 'include',
     });
-    if (!response.ok) throw new Error('역할 변경에 실패했습니다.');
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || '멤버 역할 변경에 실패했습니다.');
+    }
 };
-
 // 멤버 추가/삭제 등 필요한 다른 API 함수들...

--- a/frontend/src/api/clubMember.tsx
+++ b/frontend/src/api/clubMember.tsx
@@ -4,6 +4,8 @@ import { components } from '@/types/backend/apiV1/schema';
 
 type ClubMembersResponse = components['schemas']['RsDataClubMemberResponse'];
 type MemberInfo = components['schemas']['ClubMemberInfo'];
+type ClubMemberRegisterRequest = components['schemas']['ClubMemberRegisterRequest'];
+type ClubMemberRegisterInfo = components['schemas']['ClubMemberRegisterInfo'];
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
 
@@ -69,5 +71,28 @@ export const deleteMember = async (clubId: string, memberId: number) => {
     if (!response.ok) {
         const errorData = await response.json();
         throw new Error(errorData.message || '멤버 삭제에 실패했습니다.');
+    }
+};
+
+// 클럽에 멤버 추가
+export const addMembers = async (clubId: string, emails: string[]) => {
+    // emails 배열을 ClubMemberRegisterInfo 배열로 변환 (role은 'PARTICIPANT'로 고정)
+    const members: ClubMemberRegisterInfo[] = emails.map(email => ({
+        email,
+        role: 'PARTICIPANT',
+    }));
+
+    // ClubMemberRegisterRequest 객체 생성
+    const body: ClubMemberRegisterRequest = { members };
+
+    const response = await fetch(`${API_URL}/api/v1/clubs/${clubId}/members`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        credentials: 'include',
+    });
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || '멤버 추가에 실패했습니다.');
     }
 };

--- a/frontend/src/api/clubMember.tsx
+++ b/frontend/src/api/clubMember.tsx
@@ -1,0 +1,53 @@
+// src/services/club.ts
+
+import { components } from '@/types/backend/apiV1/schema';
+
+type ClubMembersResponse = components['schemas']['RsDataClubMemberResponse'];
+type MemberInfo = components['schemas']['ClubMemberInfo'];
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+
+// 멤버 목록 조회
+export const getClubMembers = async (clubId: string): Promise<MemberInfo[]> => {
+    const response = await fetch(`${API_URL}/api/v1/clubs/${clubId}/members`, {
+        method: 'GET',
+        credentials: 'include',
+    });
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || '멤버 목록을 불러오는 데 실패했습니다.');
+    }
+    const result: ClubMembersResponse = await response.json();
+    return result.data?.members || [];
+};
+
+// 가입 신청 승인
+export const approveApplication = async (clubId: string, memberId: number) => {
+    const response = await fetch(`${API_URL}/api/v1/clubs/${clubId}/members/${memberId}/approval`, {
+        method: 'PATCH',
+        credentials: 'include',
+    });
+    if (!response.ok) throw new Error('가입 승인에 실패했습니다.');
+};
+
+// 가입 신청 거절
+export const rejectApplication = async (clubId: string, memberId: number) => {
+    const response = await fetch(`${API_URL}/api/v1/clubs/${clubId}/members/${memberId}/approval`, {
+        method: 'DELETE',
+        credentials: 'include',
+    });
+    if (!response.ok) throw new Error('가입 거절에 실패했습니다.');
+};
+
+// 멤버 역할 변경
+export const changeMemberRole = async (clubId: string, memberId: number, role: 'MANAGER' | 'PARTICIPANT') => {
+    const response = await fetch(`${API_URL}/api/v1/clubs/${clubId}/members/${memberId}/role`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role }),
+        credentials: 'include',
+    });
+    if (!response.ok) throw new Error('역할 변경에 실패했습니다.');
+};
+
+// 멤버 추가/삭제 등 필요한 다른 API 함수들...

--- a/frontend/src/api/clubMember.tsx
+++ b/frontend/src/api/clubMember.tsx
@@ -74,8 +74,8 @@ export const deleteMember = async (clubId: string, memberId: number) => {
     }
 };
 
-// 클럽에 멤버 추가
-export const addMembers = async (clubId: string, emails: string[]) => {
+// 클럽에 멤버 초대
+export const inviteMembers = async (clubId: string, emails: string[]) => {
     // emails 배열을 ClubMemberRegisterInfo 배열로 변환 (role은 'PARTICIPANT'로 고정)
     const members: ClubMemberRegisterInfo[] = emails.map(email => ({
         email,

--- a/frontend/src/api/clubMember.tsx
+++ b/frontend/src/api/clubMember.tsx
@@ -59,4 +59,15 @@ export const changeMemberRole = async (clubId: string, memberId: number, role: '
         throw new Error(errorData.message || '멤버 역할 변경에 실패했습니다.');
     }
 };
-// 멤버 추가/삭제 등 필요한 다른 API 함수들...
+
+// 클럽에서 멤버 삭제
+export const deleteMember = async (clubId: string, memberId: number) => {
+    const response = await fetch(`${API_URL}/api/v1/clubs/${clubId}/members/${memberId}`, {
+        method: 'DELETE',
+        credentials: 'include',
+    });
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || '멤버 삭제에 실패했습니다.');
+    }
+};

--- a/frontend/src/api/members.ts
+++ b/frontend/src/api/members.ts
@@ -24,7 +24,7 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8
 export async function fetcher(url: string, options: RequestInit = {}) {
   // localStorage에서 토큰을 가져옵니다.
   const accessToken = typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
-  
+
   // Headers 객체를 사용하여 헤더를 안전하게 관리합니다.
   const headers = new Headers(options.headers);
 
@@ -41,6 +41,7 @@ export async function fetcher(url: string, options: RequestInit = {}) {
   const response = await fetch(`${API_BASE_URL}${url}`, {
     ...options,
     headers,
+    credentials: 'include', // 쿠키를 포함하여 요청
   });
 
   if (!response.ok) {

--- a/frontend/src/api/myClub.tsx
+++ b/frontend/src/api/myClub.tsx
@@ -50,3 +50,22 @@ export const applyToJoinClub = async (clubId: string): Promise<SimpleClubInfo> =
 
     return data.data;
 }
+
+/**
+ * 모임 탈퇴
+ * @param clubId 모임 ID
+ */
+export const leaveClub = async (clubId: string): Promise<void> => {
+    const response = await fetch(`${API_URL}/api/v1/my-clubs/${clubId}/withdraw`, {
+        method: 'DELETE',
+        credentials: 'include', // 쿠키를 포함하여 요청
+    });
+
+    if (!response.ok) {
+        const data = await response.json();
+        if (!('code' in data) || !('message' in data)) {
+            throw new Error('모임 탈퇴에 실패했습니다.');
+        }
+        throw new Error(data.code + " : " + (data.message || '모임 탈퇴에 실패했습니다.'));
+    }
+}

--- a/frontend/src/app/clubs/[clubId]/members/page.tsx
+++ b/frontend/src/app/clubs/[clubId]/members/page.tsx
@@ -1,21 +1,71 @@
+'use client';
+
 import { getClubMembers } from '@/api/clubMember';
+import { getMyInfoInClub } from '@/api/myClub';
+import { useState, useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { components } from '@/types/backend/apiV1/schema';
 import MemberManagement from '@/components/domain/clubMembers/MemberManagement';
+import LoadingSpinner from '@/components/global/LoadingSpinner';
+import ClubInfoSideMenu from '@/components/domain/clubs/clubInfoSideMenu';
 
-interface MembersPageProps {
-    params: { slug: string }; // [slug]는 clubId로 간주
-}
+type MemberInfo = components['schemas']['ClubMemberInfo'];
 
-export default async function MembersPage({ params }: MembersPageProps) {
-    const clubId = params.slug;
+export default function MembersPage() {
+    const params = useParams();
+    const clubId = params.clubId as string;
+    const [myInfo, setMyInfo] = useState<components['schemas']['MyInfoInClub'] | null>(null);
+    const [initialMembers, setInitialMembers] = useState<MemberInfo[]>([]);
+    const [error, setError] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
 
-    // 서버에서 초기 멤버 데이터를 모두 가져옴
-    const initialMembers = await getClubMembers(clubId);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            setIsLoading(true);
+            try {
+                // 순차 호출 (병렬도 가능)
+                const initialMembers = await getClubMembers(clubId);
+                const myInfo = await getMyInfoInClub(clubId);
+
+                if (!initialMembers) {
+                    throw new Error('멤버 목록을 불러오는 데 실패했습니다.');
+                }
+                setInitialMembers(initialMembers);
+                setMyInfo(myInfo);
+            } catch (err) {
+                setError(err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다.');
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchData();
+    }, [clubId]);
+
+
+    // 가드 클로즈 : 로딩 중
+    if (isLoading) return <LoadingSpinner />;
+
+    // 가드 클로즈 : 에러 발생
+    const errorMessage = error;
+    if (errorMessage) {
+        return <div className="text-center py-12">{errorMessage}</div>;
+    }
+
 
     return (
-        <div className="container mx-auto p-4">
+        <div className="max-w-7xl mx-auto p-4">
             <h1 className="text-3xl font-bold mb-6">멤버 관리</h1>
-            {/* 클라이언트 컴포넌트에 초기 데이터를 props로 전달 */}
-            <MemberManagement clubId={clubId} initialMembers={initialMembers} />
+            <section className="flex" style={{ height: 'calc(90vh - 64px)' }}>
+                <aside className="w-1/5 pr-4">
+                    <ClubInfoSideMenu isHost={myInfo?.role === 'HOST'} />
+                </aside>
+                <section className="w-4/5">
+                    {/* 클라이언트 컴포넌트에 초기 데이터를 props로 전달 */}
+                    <MemberManagement clubId={clubId} initialMembers={initialMembers} />
+                </section>
+            </section>
         </div>
     );
 }

--- a/frontend/src/app/clubs/[clubId]/members/page.tsx
+++ b/frontend/src/app/clubs/[clubId]/members/page.tsx
@@ -62,7 +62,7 @@ export default function MembersPage() {
                 </aside>
                 <section className="w-4/5">
                     {/* 클라이언트 컴포넌트에 초기 데이터를 props로 전달 */}
-                    <MemberManagement clubId={clubId} initialMembers={initialMembers} />
+                    <MemberManagement clubId={clubId} initialMembers={initialMembers} isHost={myInfo?.role === 'HOST'} />
                 </section>
             </section>
         </div>

--- a/frontend/src/app/clubs/[clubId]/members/page.tsx
+++ b/frontend/src/app/clubs/[clubId]/members/page.tsx
@@ -43,7 +43,6 @@ export default function MembersPage() {
         fetchData();
     }, [clubId]);
 
-
     // 가드 클로즈 : 로딩 중
     if (isLoading) return <LoadingSpinner />;
 

--- a/frontend/src/app/clubs/[clubId]/members/page.tsx
+++ b/frontend/src/app/clubs/[clubId]/members/page.tsx
@@ -1,0 +1,21 @@
+import { getClubMembers } from '@/api/clubMember';
+import MemberManagement from '@/components/domain/clubMembers/MemberManagement';
+
+interface MembersPageProps {
+    params: { slug: string }; // [slug]는 clubId로 간주
+}
+
+export default async function MembersPage({ params }: MembersPageProps) {
+    const clubId = params.slug;
+
+    // 서버에서 초기 멤버 데이터를 모두 가져옴
+    const initialMembers = await getClubMembers(clubId);
+
+    return (
+        <div className="container mx-auto p-4">
+            <h1 className="text-3xl font-bold mb-6">멤버 관리</h1>
+            {/* 클라이언트 컴포넌트에 초기 데이터를 props로 전달 */}
+            <MemberManagement clubId={clubId} initialMembers={initialMembers} />
+        </div>
+    );
+}

--- a/frontend/src/app/clubs/[clubId]/page.tsx
+++ b/frontend/src/app/clubs/[clubId]/page.tsx
@@ -53,6 +53,11 @@ export default function ClubPage() {
                     throw new Error('403 : 가입 신청 중인 모임입니다. 가입 승인이 필요합니다.');
                 }
 
+                // WITHDRAWN 상태인 경우, 접근 금지
+                if (myInfo.state === 'WITHDRAWN') {
+                    throw new Error('404 : 클럽 멤버 정보가 존재하지 않습니다.');
+                }
+
                 setClubInfo(data.data);
                 setMyInfo(myInfo);
             } catch (err) {

--- a/frontend/src/app/clubs/[clubId]/page.tsx
+++ b/frontend/src/app/clubs/[clubId]/page.tsx
@@ -78,11 +78,11 @@ export default function ClubPage() {
     return (
         <div className="max-w-7xl mx-auto p-4">
             <h1 className="text-2xl font-bold mb-4">{clubId}번 모임 페이지</h1>
-            <section className="flex">
+            <section className="flex" style={{ height: 'calc(90vh - 64px)' }}>
                 <aside className="w-1/5 pr-4">
                     <ClubInfoSideMenu isHost={myInfo?.role === 'HOST'} />
                 </aside>
-                <section className="w-4/5">
+                <section className="w-4/5 overflow-y-auto " style={{ maxHeight: '100%', borderRadius: '8px' }}>
                     {clubInfo ? <ClubInfo club={clubInfo} /> : <div className="text-center">클럽 정보를 불러오는 중입니다...</div>}
                 </section>
             </section>

--- a/frontend/src/components/domain/clubMembers/MemberList.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberList.tsx
@@ -9,6 +9,7 @@ interface MemberListProps {
     onApprove: (memberId: number) => void;
     onReject: (memberId: number) => void;
     onChangeRole: (memberId: number, role: 'MANAGER' | 'PARTICIPANT') => void;
+    onDelete: (memberId: number) => void;
 }
 
 export default function MemberList({ members, ...handlers }: MemberListProps) {

--- a/frontend/src/components/domain/clubMembers/MemberList.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberList.tsx
@@ -47,19 +47,17 @@ export default function MemberList({ members, state, ...handlers }: MemberListPr
     return (
         <div>
             {
-                (state === 'INVITED') && (
-                    <p className="text-center text-gray-500 py-4">
-                        초대된 멤버는 클럽에 참여하기 전까지는 목록에 표시되지 않습니다.
-                    </p>
-                )
-            }
-            <ul className="bg-white rounded-lg shadow">
-                {members.map(member => (
-                    <MultiEmailInput
+                state === 'INVITED' && (
+                    < MultiEmailInput
                         onSubmit={handleInviteMembers}
                         label="모임에 초대할 멤버의 이메일 주소를 입력하세요"
                         placeholder="예: user@example.com"
                     />
+                )
+            }
+            <ul className="bg-white rounded-lg shadow">
+                {members.map(member => (
+                    <MemberListItem key={member.clubMemberId} member={member} {...handlers} />
                 ))}
             </ul>
         </div>

--- a/frontend/src/components/domain/clubMembers/MemberList.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberList.tsx
@@ -12,6 +12,7 @@ type MemberInfo = components['schemas']['ClubMemberInfo'];
 interface MemberListProps {
     members: MemberInfo[];
     state?: 'JOINING' | 'APPLYING' | 'INVITED';
+    isHost?: boolean;
     onApprove: (memberId: number) => void;
     onReject: (memberId: number) => void;
     onChangeRole: (memberId: number, role: 'MANAGER' | 'PARTICIPANT') => void;
@@ -19,13 +20,13 @@ interface MemberListProps {
     onInvite: (emails: string[]) => void;
 }
 
-export default function MemberList({ members, state, onInvite, ...handlers }: MemberListProps) {
+export default function MemberList({ members, state, isHost, onInvite, ...handlers }: MemberListProps) {
     const params = useParams();
     const clubId = params.clubId as string;
 
     return (
         <div>
-            {state === 'INVITED' && (
+            {state === 'INVITED' && isHost && (
                 <div className="mb-4">
                     <MultiEmailInput
                         onSubmit={onInvite}
@@ -39,7 +40,7 @@ export default function MemberList({ members, state, onInvite, ...handlers }: Me
             ) : (
                 <ul className="bg-white rounded-lg shadow">
                     {members.map(member => (
-                        <MemberListItem key={member.clubMemberId} member={member} {...handlers} />
+                        <MemberListItem key={member.clubMemberId} member={member} isHost={isHost} {...handlers} />
                     ))}
                 </ul>
             )}

--- a/frontend/src/components/domain/clubMembers/MemberList.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberList.tsx
@@ -1,27 +1,67 @@
+'use client';
+
+import { useState, useEffect } from 'react';
 import MemberListItem from './MemberListItem';
 import { components } from '@/types/backend/apiV1/schema';
+import MultiEmailInput from './MultiEmailInput';
 
 type MemberInfo = components['schemas']['ClubMemberInfo'];
 
 // MemberListItem에서 필요한 함수들을 props로 내려받습니다.
 interface MemberListProps {
     members: MemberInfo[];
+    state?: 'JOINING' | 'APPLYING' | 'INVITED';
     onApprove: (memberId: number) => void;
     onReject: (memberId: number) => void;
     onChangeRole: (memberId: number, role: 'MANAGER' | 'PARTICIPANT') => void;
     onDelete: (memberId: number) => void;
 }
 
-export default function MemberList({ members, ...handlers }: MemberListProps) {
+export default function MemberList({ members, state, ...handlers }: MemberListProps) {
+    //const [emails, setEmails] = useState<string[]>([]);
+
+    const handleInviteMembers = (emails: string[]) => {
+        console.log("초대할 최종 이메일 목록:", emails);
+        // 여기에 실제 API 호출 로직을 구현합니다.
+        // 예: await inviteMembersAPI(clubId, emails);
+        alert(`${emails.length}명의 멤버에게 초대 이메일을 보냅니다.`);
+    };
+
     if (members.length === 0) {
-        return <p className="text-center text-gray-500 py-10">해당하는 멤버가 없습니다.</p>;
+        return (
+            <div>
+                {
+                    state === 'INVITED' && (
+                        < MultiEmailInput
+                            onSubmit={handleInviteMembers}
+                            label="모임에 초대할 멤버의 이메일 주소를 입력하세요"
+                            placeholder="예: user@example.com"
+                        />
+                    )
+                }
+                <p className="text-center text-gray-500 py-10">해당하는 멤버가 없습니다.</p>
+            </div>
+        );
     }
 
     return (
-        <ul className="bg-white rounded-lg shadow">
-            {members.map(member => (
-                <MemberListItem key={member.clubMemberId} member={member} {...handlers} />
-            ))}
-        </ul>
+        <div>
+            {
+                (state === 'INVITED') && (
+                    <p className="text-center text-gray-500 py-4">
+                        초대된 멤버는 클럽에 참여하기 전까지는 목록에 표시되지 않습니다.
+                    </p>
+                )
+            }
+            <ul className="bg-white rounded-lg shadow">
+                {members.map(member => (
+                    <MultiEmailInput
+                        onSubmit={handleInviteMembers}
+                        label="모임에 초대할 멤버의 이메일 주소를 입력하세요"
+                        placeholder="예: user@example.com"
+                    />
+                ))}
+            </ul>
+        </div>
     );
 }

--- a/frontend/src/components/domain/clubMembers/MemberList.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberList.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import MemberListItem from './MemberListItem';
 import { components } from '@/types/backend/apiV1/schema';
 import MultiEmailInput from './MultiEmailInput';
+import { inviteMembers } from '@/api/clubMember';
+import { useParams } from 'next/navigation';
 
 type MemberInfo = components['schemas']['ClubMemberInfo'];
 
@@ -18,48 +19,42 @@ interface MemberListProps {
 }
 
 export default function MemberList({ members, state, ...handlers }: MemberListProps) {
-    //const [emails, setEmails] = useState<string[]>([]);
+    const params = useParams();
+    const clubId = params.clubId as string;
 
     const handleInviteMembers = (emails: string[]) => {
         console.log("초대할 최종 이메일 목록:", emails);
         // 여기에 실제 API 호출 로직을 구현합니다.
-        // 예: await inviteMembersAPI(clubId, emails);
-        alert(`${emails.length}명의 멤버에게 초대 이메일을 보냅니다.`);
+        inviteMembers(clubId, emails)
+            .then(() => {
+                alert('초대 이메일이 성공적으로 발송되었습니다.');
+            })
+            .catch((error) => {
+                console.error('초대 이메일 발송 실패:', error);
+                alert('초대 이메일 발송에 실패했습니다. 다시 시도해주세요.');
+            });
     };
-
-    if (members.length === 0) {
-        return (
-            <div>
-                {
-                    state === 'INVITED' && (
-                        < MultiEmailInput
-                            onSubmit={handleInviteMembers}
-                            label="모임에 초대할 멤버의 이메일 주소를 입력하세요"
-                            placeholder="예: user@example.com"
-                        />
-                    )
-                }
-                <p className="text-center text-gray-500 py-10">해당하는 멤버가 없습니다.</p>
-            </div>
-        );
-    }
 
     return (
         <div>
-            {
-                state === 'INVITED' && (
-                    < MultiEmailInput
+            {state === 'INVITED' && (
+                <div className="mb-4">
+                    <MultiEmailInput
                         onSubmit={handleInviteMembers}
                         label="모임에 초대할 멤버의 이메일 주소를 입력하세요"
                         placeholder="예: user@example.com"
                     />
-                )
-            }
-            <ul className="bg-white rounded-lg shadow">
-                {members.map(member => (
-                    <MemberListItem key={member.clubMemberId} member={member} {...handlers} />
-                ))}
-            </ul>
+                </div>
+            )}
+            {members.length === 0 ? (
+                <p className="text-center text-gray-500 py-10">해당하는 멤버가 없습니다.</p>
+            ) : (
+                <ul className="bg-white rounded-lg shadow">
+                    {members.map(member => (
+                        <MemberListItem key={member.clubMemberId} member={member} {...handlers} />
+                    ))}
+                </ul>
+            )}
         </div>
     );
 }

--- a/frontend/src/components/domain/clubMembers/MemberList.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberList.tsx
@@ -1,0 +1,26 @@
+import MemberListItem from './MemberListItem';
+import { components } from '@/types/backend/apiV1/schema';
+
+type MemberInfo = components['schemas']['ClubMemberInfo'];
+
+// MemberListItem에서 필요한 함수들을 props로 내려받습니다.
+interface MemberListProps {
+    members: MemberInfo[];
+    onApprove: (memberId: number) => void;
+    onReject: (memberId: number) => void;
+    onChangeRole: (memberId: number, role: 'MANAGER' | 'PARTICIPANT') => void;
+}
+
+export default function MemberList({ members, ...handlers }: MemberListProps) {
+    if (members.length === 0) {
+        return <p className="text-center text-gray-500 py-10">해당하는 멤버가 없습니다.</p>;
+    }
+
+    return (
+        <ul className="bg-white rounded-lg shadow">
+            {members.map(member => (
+                <MemberListItem key={member.clubMemberId} member={member} {...handlers} />
+            ))}
+        </ul>
+    );
+}

--- a/frontend/src/components/domain/clubMembers/MemberList.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberList.tsx
@@ -16,31 +16,19 @@ interface MemberListProps {
     onReject: (memberId: number) => void;
     onChangeRole: (memberId: number, role: 'MANAGER' | 'PARTICIPANT') => void;
     onDelete: (memberId: number) => void;
+    onInvite: (emails: string[]) => void;
 }
 
-export default function MemberList({ members, state, ...handlers }: MemberListProps) {
+export default function MemberList({ members, state, onInvite, ...handlers }: MemberListProps) {
     const params = useParams();
     const clubId = params.clubId as string;
-
-    const handleInviteMembers = (emails: string[]) => {
-        console.log("초대할 최종 이메일 목록:", emails);
-        // 여기에 실제 API 호출 로직을 구현합니다.
-        inviteMembers(clubId, emails)
-            .then(() => {
-                alert('초대 이메일이 성공적으로 발송되었습니다.');
-            })
-            .catch((error) => {
-                console.error('초대 이메일 발송 실패:', error);
-                alert('초대 이메일 발송에 실패했습니다. 다시 시도해주세요.');
-            });
-    };
 
     return (
         <div>
             {state === 'INVITED' && (
                 <div className="mb-4">
                     <MultiEmailInput
-                        onSubmit={handleInviteMembers}
+                        onSubmit={onInvite}
                         label="모임에 초대할 멤버의 이메일 주소를 입력하세요"
                         placeholder="예: user@example.com"
                     />

--- a/frontend/src/components/domain/clubMembers/MemberListItem.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberListItem.tsx
@@ -13,7 +13,7 @@ interface MemberListItemProps {
 }
 
 export default function MemberListItem({ member, onApprove, onReject, onChangeRole }: MemberListItemProps) {
-    const memberId = member.clubMemberId!;
+    const memberId = member.memberId!;
 
     const handleRoleChange = () => {
         const newRole = member.role === 'MANAGER' ? 'PARTICIPANT' : 'MANAGER';

--- a/frontend/src/components/domain/clubMembers/MemberListItem.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberListItem.tsx
@@ -10,9 +10,10 @@ interface MemberListItemProps {
     onApprove: (memberId: number) => void;
     onReject: (memberId: number) => void;
     onChangeRole: (memberId: number, role: 'MANAGER' | 'PARTICIPANT') => void;
+    onDelete: (memberId: number) => void;
 }
 
-export default function MemberListItem({ member, onApprove, onReject, onChangeRole }: MemberListItemProps) {
+export default function MemberListItem({ member, onApprove, onReject, onChangeRole, onDelete }: MemberListItemProps) {
     const memberId = member.memberId!;
 
     const handleRoleChange = () => {
@@ -70,7 +71,7 @@ export default function MemberListItem({ member, onApprove, onReject, onChangeRo
                         <button onClick={handleRoleChange} className="btn-secondary">
                             {member.role === 'MANAGER' ? '참여자로 변경' : '매니저로 임명'}
                         </button>
-                        <button className="btn-danger">삭제</button>
+                        <button onClick={() => onDelete(memberId)} className="btn-danger">삭제</button>
                     </>
                 )}
             </div>

--- a/frontend/src/components/domain/clubMembers/MemberListItem.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberListItem.tsx
@@ -17,6 +17,10 @@ interface MemberListItemProps {
 export default function MemberListItem({ member, isHost, onApprove, onReject, onChangeRole, onDelete }: MemberListItemProps) {
     const memberId = member.memberId!;
 
+    if (!memberId) {
+        return <li className="text-red-500">멤버 ID가 없습니다.</li>;
+    }
+
     const handleRoleChange = () => {
         const newRole = member.role === 'MANAGER' ? 'PARTICIPANT' : 'MANAGER';
         onChangeRole(memberId, newRole);
@@ -28,7 +32,7 @@ export default function MemberListItem({ member, isHost, onApprove, onReject, on
                 {member.profileImageUrl ? (
                     <Image
                         src={member.profileImageUrl}
-                        alt={member.nickname!}
+                        alt={member.nickname || '프로필 이미지'}
                         width={40}
                         height={40}
                         className="rounded-full"
@@ -70,7 +74,7 @@ export default function MemberListItem({ member, isHost, onApprove, onReject, on
                     )}
                     {member.state === 'JOINING' && member.role !== 'HOST' && (
                         <>
-                            <button onClick={handleRoleChange} className="btn-secondary">
+                            <button onClick={handleRoleChange} >
                                 {member.role === 'MANAGER' ? '참여자로 변경' : '매니저로 임명'}
                             </button>
                             <button onClick={() => onDelete(memberId)} className="btn-danger">삭제</button>

--- a/frontend/src/components/domain/clubMembers/MemberListItem.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberListItem.tsx
@@ -7,13 +7,14 @@ type MemberInfo = components['schemas']['ClubMemberInfo'];
 
 interface MemberListItemProps {
     member: MemberInfo;
+    isHost?: boolean;
     onApprove: (memberId: number) => void;
     onReject: (memberId: number) => void;
     onChangeRole: (memberId: number, role: 'MANAGER' | 'PARTICIPANT') => void;
     onDelete: (memberId: number) => void;
 }
 
-export default function MemberListItem({ member, onApprove, onReject, onChangeRole, onDelete }: MemberListItemProps) {
+export default function MemberListItem({ member, isHost, onApprove, onReject, onChangeRole, onDelete }: MemberListItemProps) {
     const memberId = member.memberId!;
 
     const handleRoleChange = () => {
@@ -59,22 +60,24 @@ export default function MemberListItem({ member, onApprove, onReject, onChangeRo
             </div>
 
             {/* 조건부 버튼 렌더링 */}
-            <div className="flex space-x-2">
-                {member.state === 'APPLYING' && (
-                    <>
-                        <button onClick={() => onApprove(memberId)} className="btn-primary">수락</button>
-                        <button onClick={() => onReject(memberId)} className="btn-secondary">거절</button>
-                    </>
-                )}
-                {member.state === 'JOINING' && member.role !== 'HOST' && (
-                    <>
-                        <button onClick={handleRoleChange} className="btn-secondary">
-                            {member.role === 'MANAGER' ? '참여자로 변경' : '매니저로 임명'}
-                        </button>
-                        <button onClick={() => onDelete(memberId)} className="btn-danger">삭제</button>
-                    </>
-                )}
-            </div>
+            {isHost && (
+                <div className="flex space-x-2">
+                    {member.state === 'APPLYING' && (
+                        <>
+                            <button onClick={() => onApprove(memberId)} className="btn-primary">수락</button>
+                            <button onClick={() => onReject(memberId)} className="btn-secondary">거절</button>
+                        </>
+                    )}
+                    {member.state === 'JOINING' && member.role !== 'HOST' && (
+                        <>
+                            <button onClick={handleRoleChange} className="btn-secondary">
+                                {member.role === 'MANAGER' ? '참여자로 변경' : '매니저로 임명'}
+                            </button>
+                            <button onClick={() => onDelete(memberId)} className="btn-danger">삭제</button>
+                        </>
+                    )}
+                </div>
+            )}
         </li>
     );
 }

--- a/frontend/src/components/domain/clubMembers/MemberListItem.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberListItem.tsx
@@ -23,10 +23,37 @@ export default function MemberListItem({ member, onApprove, onReject, onChangeRo
     return (
         <li className="flex items-center justify-between p-4 border-b">
             <div className="flex items-center space-x-4">
-                <Image src={member.profileImageUrl || '/default-profile.png'} alt={member.nickname!} width={40} height={40} className="rounded-full" />
+                {member.profileImageUrl ? (
+                    <Image
+                        src={member.profileImageUrl}
+                        alt={member.nickname!}
+                        width={40}
+                        height={40}
+                        className="rounded-full"
+                    />
+                ) : (
+                    <span className="w-10 h-10 flex items-center justify-center rounded-full bg-gray-100">
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 24 24"
+                            fill="currentColor"
+                            className="w-8 h-8 text-gray-500"
+                        >
+                            <path
+                                fillRule="evenodd"
+                                d="M7.5 6a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM3.751 20.105a8.25 8.25 0 0116.498 0 .75.75 0 01-.75.75H4.501a.75.75 0 01-.75-.75z"
+                                clipRule="evenodd"
+                            />
+                        </svg>
+                    </span>
+                )}
                 <div>
-                    <p className="font-bold">{member.nickname} <span className="text-gray-500 font-normal">#{member.tag}</span></p>
-                    <p className="text-sm text-gray-600">{member.role} / {member.memberType}</p>
+                    <p className="font-bold">
+                        {member.nickname} <span className="text-gray-500 font-normal">#{member.tag}</span>
+                    </p>
+                    <p className="text-sm text-gray-600">
+                        {member.role} / {member.memberType}
+                    </p>
                 </div>
             </div>
 

--- a/frontend/src/components/domain/clubMembers/MemberListItem.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberListItem.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Image from 'next/image';
+import { components } from '@/types/backend/apiV1/schema';
+
+type MemberInfo = components['schemas']['ClubMemberInfo'];
+
+interface MemberListItemProps {
+    member: MemberInfo;
+    onApprove: (memberId: number) => void;
+    onReject: (memberId: number) => void;
+    onChangeRole: (memberId: number, role: 'MANAGER' | 'PARTICIPANT') => void;
+}
+
+export default function MemberListItem({ member, onApprove, onReject, onChangeRole }: MemberListItemProps) {
+    const memberId = member.clubMemberId!;
+
+    const handleRoleChange = () => {
+        const newRole = member.role === 'MANAGER' ? 'PARTICIPANT' : 'MANAGER';
+        onChangeRole(memberId, newRole);
+    };
+
+    return (
+        <li className="flex items-center justify-between p-4 border-b">
+            <div className="flex items-center space-x-4">
+                <Image src={member.profileImageUrl || '/default-profile.png'} alt={member.nickname!} width={40} height={40} className="rounded-full" />
+                <div>
+                    <p className="font-bold">{member.nickname} <span className="text-gray-500 font-normal">#{member.tag}</span></p>
+                    <p className="text-sm text-gray-600">{member.role} / {member.memberType}</p>
+                </div>
+            </div>
+
+            {/* 조건부 버튼 렌더링 */}
+            <div className="flex space-x-2">
+                {member.state === 'APPLYING' && (
+                    <>
+                        <button onClick={() => onApprove(memberId)} className="btn-primary">수락</button>
+                        <button onClick={() => onReject(memberId)} className="btn-secondary">거절</button>
+                    </>
+                )}
+                {member.state === 'JOINING' && member.role !== 'HOST' && (
+                    <>
+                        <button onClick={handleRoleChange} className="btn-secondary">
+                            {member.role === 'MANAGER' ? '참여자로 변경' : '매니저로 임명'}
+                        </button>
+                        <button className="btn-danger">삭제</button>
+                    </>
+                )}
+            </div>
+        </li>
+    );
+}

--- a/frontend/src/components/domain/clubMembers/MemberManagement.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberManagement.tsx
@@ -56,6 +56,7 @@ export default function MemberManagement({ clubId, initialMembers }: MemberManag
             <MemberTabs clubId={clubId} />
             <MemberList
                 members={filteredMembers}
+                state={currentState as 'JOINING' | 'APPLYING' | 'INVITED'}
                 onApprove={handleApprove}
                 onReject={handleReject}
                 onChangeRole={handleChangeRole}

--- a/frontend/src/components/domain/clubMembers/MemberManagement.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberManagement.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo, useEffect } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { components } from '@/types/backend/apiV1/schema';
 import MemberTabs from './MemberTabs';
 import MemberList from './MemberList';
@@ -15,6 +15,8 @@ interface MemberManagementProps {
 }
 
 export default function MemberManagement({ clubId, initialMembers }: MemberManagementProps) {
+    const router = useRouter();
+
     const [members, setMembers] = useState(initialMembers);
     const searchParams = useSearchParams();
     const currentState = searchParams.get('state') || 'JOINING';
@@ -35,7 +37,7 @@ export default function MemberManagement({ clubId, initialMembers }: MemberManag
             // 성공 시, 실제로는 전체 목록을 다시 fetch 하는 것이 가장 정확합니다.
             // 여기서는 예시로 로컬 상태를 직접 조작합니다.
             alert('작업이 완료되었습니다.');
-            // router.refresh(); 또는 전체 데이터 refetch
+            router.refresh();
         } catch (err) {
             alert(err instanceof Error ? err.message : '작업에 실패했습니다.');
         }

--- a/frontend/src/components/domain/clubMembers/MemberManagement.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberManagement.tsx
@@ -27,8 +27,13 @@ export default function MemberManagement({ clubId, initialMembers, isHost }: Mem
     }, [initialMembers]);
 
     const refreshMembers = async () => {
-        const updatedMembers = await getClubMembers(clubId);
-        setMembers(updatedMembers);
+        try {
+            const updatedMembers = await getClubMembers(clubId);
+            setMembers(updatedMembers);
+        } catch (err) {
+            console.error('멤버 목록을 불러오는 데 실패했습니다.', err);
+            throw new Error('멤버 목록을 불러오는 데 실패했습니다.');
+        }
     };
 
     const filteredMembers = useMemo(() => {

--- a/frontend/src/components/domain/clubMembers/MemberManagement.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberManagement.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useState, useMemo, useEffect } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { components } from '@/types/backend/apiV1/schema';
+import { getClubMembers } from '@/api/clubMember';
 import MemberTabs from './MemberTabs';
 import MemberList from './MemberList';
 import { approveApplication, rejectApplication, changeMemberRole } from '@/api/clubMember';
@@ -15,8 +16,6 @@ interface MemberManagementProps {
 }
 
 export default function MemberManagement({ clubId, initialMembers }: MemberManagementProps) {
-    const router = useRouter();
-
     const [members, setMembers] = useState(initialMembers);
     const searchParams = useSearchParams();
     const currentState = searchParams.get('state') || 'JOINING';
@@ -26,6 +25,10 @@ export default function MemberManagement({ clubId, initialMembers }: MemberManag
         setMembers(initialMembers);
     }, [initialMembers]);
 
+    const refreshMembers = async () => {
+        const updatedMembers = await getClubMembers(clubId);
+        setMembers(updatedMembers);
+    };
 
     const filteredMembers = useMemo(() => {
         return members.filter(member => member.state === currentState);
@@ -37,7 +40,7 @@ export default function MemberManagement({ clubId, initialMembers }: MemberManag
             // 성공 시, 실제로는 전체 목록을 다시 fetch 하는 것이 가장 정확합니다.
             // 여기서는 예시로 로컬 상태를 직접 조작합니다.
             alert('작업이 완료되었습니다.');
-            router.refresh();
+            await refreshMembers();
         } catch (err) {
             alert(err instanceof Error ? err.message : '작업에 실패했습니다.');
         }

--- a/frontend/src/components/domain/clubMembers/MemberManagement.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberManagement.tsx
@@ -6,7 +6,7 @@ import { components } from '@/types/backend/apiV1/schema';
 import { getClubMembers } from '@/api/clubMember';
 import MemberTabs from './MemberTabs';
 import MemberList from './MemberList';
-import { approveApplication, rejectApplication, changeMemberRole, deleteMember } from '@/api/clubMember';
+import { approveApplication, rejectApplication, changeMemberRole, deleteMember, inviteMembers } from '@/api/clubMember';
 
 type MemberInfo = components['schemas']['ClubMemberInfo'];
 
@@ -37,8 +37,7 @@ export default function MemberManagement({ clubId, initialMembers }: MemberManag
     const handleAction = async (action: () => Promise<void>) => {
         try {
             await action();
-            // 성공 시, 실제로는 전체 목록을 다시 fetch 하는 것이 가장 정확합니다.
-            // 여기서는 예시로 로컬 상태를 직접 조작합니다.
+
             alert('작업이 완료되었습니다.');
             await refreshMembers();
         } catch (err) {
@@ -50,6 +49,7 @@ export default function MemberManagement({ clubId, initialMembers }: MemberManag
     const handleReject = (memberId: number) => handleAction(() => rejectApplication(clubId, memberId));
     const handleChangeRole = (memberId: number, role: 'MANAGER' | 'PARTICIPANT') => handleAction(() => changeMemberRole(clubId, memberId, role));
     const handleDelete = (memberId: number) => handleAction(() => deleteMember(clubId, memberId));
+    const handleInviteMembers = (emails: string[]) => handleAction(() => inviteMembers(clubId, emails));
 
     return (
         <>
@@ -61,6 +61,7 @@ export default function MemberManagement({ clubId, initialMembers }: MemberManag
                 onReject={handleReject}
                 onChangeRole={handleChangeRole}
                 onDelete={handleDelete}
+                onInvite={handleInviteMembers}
             />
         </>
     );

--- a/frontend/src/components/domain/clubMembers/MemberManagement.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberManagement.tsx
@@ -6,7 +6,7 @@ import { components } from '@/types/backend/apiV1/schema';
 import { getClubMembers } from '@/api/clubMember';
 import MemberTabs from './MemberTabs';
 import MemberList from './MemberList';
-import { approveApplication, rejectApplication, changeMemberRole } from '@/api/clubMember';
+import { approveApplication, rejectApplication, changeMemberRole, deleteMember } from '@/api/clubMember';
 
 type MemberInfo = components['schemas']['ClubMemberInfo'];
 
@@ -49,6 +49,7 @@ export default function MemberManagement({ clubId, initialMembers }: MemberManag
     const handleApprove = (memberId: number) => handleAction(() => approveApplication(clubId, memberId));
     const handleReject = (memberId: number) => handleAction(() => rejectApplication(clubId, memberId));
     const handleChangeRole = (memberId: number, role: 'MANAGER' | 'PARTICIPANT') => handleAction(() => changeMemberRole(clubId, memberId, role));
+    const handleDelete = (memberId: number) => handleAction(() => deleteMember(clubId, memberId));
 
     return (
         <>
@@ -58,6 +59,7 @@ export default function MemberManagement({ clubId, initialMembers }: MemberManag
                 onApprove={handleApprove}
                 onReject={handleReject}
                 onChangeRole={handleChangeRole}
+                onDelete={handleDelete}
             />
         </>
     );

--- a/frontend/src/components/domain/clubMembers/MemberManagement.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberManagement.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState, useMemo, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { components } from '@/types/backend/apiV1/schema';
+import MemberTabs from './MemberTabs';
+import MemberList from './MemberList';
+import { approveApplication, rejectApplication, changeMemberRole } from '@/api/clubMember';
+
+type MemberInfo = components['schemas']['ClubMemberInfo'];
+
+interface MemberManagementProps {
+    clubId: string;
+    initialMembers: MemberInfo[];
+}
+
+export default function MemberManagement({ clubId, initialMembers }: MemberManagementProps) {
+    const [members, setMembers] = useState(initialMembers);
+    const searchParams = useSearchParams();
+    const currentState = searchParams.get('state') || 'JOINING';
+
+    // 탭이 변경될 때마다 서버 데이터를 다시 불러오고 싶다면 useEffect 사용
+    useEffect(() => {
+        setMembers(initialMembers);
+    }, [initialMembers]);
+
+
+    const filteredMembers = useMemo(() => {
+        return members.filter(member => member.state === currentState);
+    }, [members, currentState]);
+
+    const handleAction = async (action: () => Promise<void>) => {
+        try {
+            await action();
+            // 성공 시, 실제로는 전체 목록을 다시 fetch 하는 것이 가장 정확합니다.
+            // 여기서는 예시로 로컬 상태를 직접 조작합니다.
+            alert('작업이 완료되었습니다.');
+            // router.refresh(); 또는 전체 데이터 refetch
+        } catch (err) {
+            alert(err instanceof Error ? err.message : '작업에 실패했습니다.');
+        }
+    };
+
+    const handleApprove = (memberId: number) => handleAction(() => approveApplication(clubId, memberId));
+    const handleReject = (memberId: number) => handleAction(() => rejectApplication(clubId, memberId));
+    const handleChangeRole = (memberId: number, role: 'MANAGER' | 'PARTICIPANT') => handleAction(() => changeMemberRole(clubId, memberId, role));
+
+    return (
+        <>
+            <MemberTabs clubId={clubId} />
+            <MemberList
+                members={filteredMembers}
+                onApprove={handleApprove}
+                onReject={handleReject}
+                onChangeRole={handleChangeRole}
+            />
+        </>
+    );
+}

--- a/frontend/src/components/domain/clubMembers/MemberManagement.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberManagement.tsx
@@ -13,9 +13,10 @@ type MemberInfo = components['schemas']['ClubMemberInfo'];
 interface MemberManagementProps {
     clubId: string;
     initialMembers: MemberInfo[];
+    isHost: boolean;
 }
 
-export default function MemberManagement({ clubId, initialMembers }: MemberManagementProps) {
+export default function MemberManagement({ clubId, initialMembers, isHost }: MemberManagementProps) {
     const [members, setMembers] = useState(initialMembers);
     const searchParams = useSearchParams();
     const currentState = searchParams.get('state') || 'JOINING';
@@ -57,6 +58,7 @@ export default function MemberManagement({ clubId, initialMembers }: MemberManag
             <MemberList
                 members={filteredMembers}
                 state={currentState as 'JOINING' | 'APPLYING' | 'INVITED'}
+                isHost={isHost}
                 onApprove={handleApprove}
                 onReject={handleReject}
                 onChangeRole={handleChangeRole}

--- a/frontend/src/components/domain/clubMembers/MemberTabs.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberTabs.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+
+interface MemberTabsProps {
+    clubId: string;
+}
+
+export default function MemberTabs({ clubId }: MemberTabsProps) {
+    const searchParams = useSearchParams();
+    const currentState = searchParams.get('state') || 'JOINING';
+
+    const tabs = [
+        { state: 'JOINING', label: '참여중인 멤버' },
+        { state: 'APPLYING', label: '가입 신청' },
+        { state: 'INVITED', label: '초대된 멤버' },
+    ];
+
+    return (
+        <div className="mb-6 border-b">
+            <nav className="flex space-x-4">
+                {tabs.map(tab => (
+                    <Link
+                        key={tab.state}
+                        href={`/groups/${clubId}/members?state=${tab.state}`}
+                        className={`py-2 px-4 font-medium ${currentState === tab.state ? 'border-b-2 border-blue-500 text-blue-600' : 'text-gray-500 hover:text-gray-700'}`}
+                    >
+                        {tab.label}
+                    </Link>
+                ))}
+            </nav>
+        </div>
+    );
+}

--- a/frontend/src/components/domain/clubMembers/MemberTabs.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberTabs.tsx
@@ -23,7 +23,7 @@ export default function MemberTabs({ clubId }: MemberTabsProps) {
                 {tabs.map(tab => (
                     <Link
                         key={tab.state}
-                        href={`/groups/${clubId}/members?state=${tab.state}`}
+                        href={`/clubs/${clubId}/members?state=${tab.state}`}
                         className={`py-2 px-4 font-medium ${currentState === tab.state ? 'border-b-2 border-blue-500 text-blue-600' : 'text-gray-500 hover:text-gray-700'}`}
                     >
                         {tab.label}

--- a/frontend/src/components/domain/clubMembers/MultiEmailInput.tsx
+++ b/frontend/src/components/domain/clubMembers/MultiEmailInput.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useState, KeyboardEvent } from 'react';
+
+// 부모 컴포넌트에게 전달할 props 타입 정의
+interface MultiEmailInputProps {
+    initialEmails?: string[];
+    onSubmit: (emails: string[]) => void;
+    placeholder?: string;
+    label?: string;
+}
+
+export default function MultiEmailInput({
+    initialEmails = [],
+    onSubmit,
+    placeholder = "이메일을 입력하고 Enter를 누르세요...",
+    label = "초대할 멤버 이메일"
+}: MultiEmailInputProps) {
+    // 1. 상태 관리
+    const [inputValue, setInputValue] = useState(''); // 현재 입력창의 값
+    const [emails, setEmails] = useState<string[]>(initialEmails); // 추가된 이메일 목록
+    const [error, setError] = useState<string | null>(null); // 유효성 검사 에러 메시지
+
+    // 2. 이메일 유효성 검사 함수
+    const isValidEmail = (email: string) => {
+        return /\S+@\S+\.\S+/.test(email);
+    };
+
+    // 3. Enter 키 입력 처리
+    const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            e.preventDefault(); // form의 기본 제출 동작 방지
+
+            const newEmail = inputValue.trim();
+
+            if (newEmail) {
+                if (!isValidEmail(newEmail)) {
+                    setError('유효한 이메일 형식이 아닙니다.');
+                    return;
+                }
+                if (emails.includes(newEmail)) {
+                    setError('이미 추가된 이메일입니다.');
+                    return;
+                }
+
+                setEmails([...emails, newEmail]);
+                setInputValue('');
+                setError(null);
+            }
+        }
+    };
+
+    // 4. 이메일 태그 삭제 처리
+    const handleDeleteEmail = (emailToDelete: string) => {
+        setEmails(emails.filter(email => email !== emailToDelete));
+    };
+
+    // 5. 최종 제출 처리
+    const handleSubmit = () => {
+        // 입력창에 남아있는 텍스트가 유효한 이메일이면 목록에 추가 후 제출
+        const lastEmail = inputValue.trim();
+        let finalEmails = [...emails];
+
+        if (lastEmail) {
+            if (!isValidEmail(lastEmail) || emails.includes(lastEmail)) {
+                setError('입력창의 이메일이 유효하지 않거나 중복되었습니다. 확인 후 다시 시도해주세요.');
+                return;
+            }
+            finalEmails.push(lastEmail);
+        }
+
+        onSubmit(finalEmails);
+        // 제출 후 초기화
+        setEmails([]);
+        setInputValue('');
+    };
+
+    return (
+        <div className="w-full">
+            <label htmlFor="email-input" className="block text-sm font-medium text-gray-700 mb-1">
+                {label}
+            </label>
+            <div className="flex flex-wrap items-center gap-2 p-2 border border-gray-300 rounded-md focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-blue-500">
+                {emails.map((email) => (
+                    <div
+                        key={email}
+                        className="bg-blue-100 text-blue-800 text-sm font-medium px-3 py-1 rounded-full flex items-center gap-2 cursor-pointer"
+                        onClick={() => handleDeleteEmail(email)}
+                    >
+                        <span>{email}</span>
+                    </div>
+                ))}
+                <input
+                    id="email-input"
+                    type="email"
+                    value={inputValue}
+                    onChange={(e) => {
+                        setInputValue(e.target.value);
+                        if (error) setError(null); // 입력 시 에러 메시지 초기화
+                    }}
+                    onKeyDown={handleKeyDown}
+                    className="flex-grow p-1 outline-none bg-transparent text-sm"
+                    placeholder={emails.length === 0 ? placeholder : ''}
+                />
+            </div>
+            {error && <p className="text-red-500 text-xs mt-1">{error}</p>}
+
+            <div className="mt-4 text-right">
+                <button
+                    onClick={handleSubmit}
+                    className="px-6 py-2 bg-blue-600 text-white font-semibold rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                >
+                    제출하기
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/domain/clubMembers/MultiEmailInput.tsx
+++ b/frontend/src/components/domain/clubMembers/MultiEmailInput.tsx
@@ -23,7 +23,7 @@ export default function MultiEmailInput({
 
     // 2. 이메일 유효성 검사 함수
     const isValidEmail = (email: string) => {
-        return /\S+@\S+\.\S+/.test(email);
+        return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
     };
 
     // 3. Enter 키 입력 처리
@@ -82,11 +82,7 @@ export default function MultiEmailInput({
             </label>
             <div className="flex flex-wrap items-center gap-2 p-2 border border-gray-300 rounded-md focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-blue-500">
                 {emails.map((email) => (
-                    <div
-                        key={email}
-                        className="bg-blue-100 text-blue-800 text-sm font-medium px-3 py-1 rounded-full flex items-center gap-2 cursor-pointer"
-                        onClick={() => handleDeleteEmail(email)}
-                    >
+                    <div key={email} className="bg-blue-100 text-blue-800 text-sm font-medium px-3 py-1 rounded-full flex items-center gap-2" onClick={() => handleDeleteEmail(email)}>
                         <span>{email}</span>
                     </div>
                 ))}

--- a/frontend/src/components/domain/clubs/clubInfoSideMenu.tsx
+++ b/frontend/src/components/domain/clubs/clubInfoSideMenu.tsx
@@ -76,8 +76,29 @@ const ClubInfoSideMenu: React.FC<ClubInfoSideMenuProps> = ({ isHost }) => {
                 ))}
             </ul>
             {isHost && (
-                <footer style={{ padding: '16px', textAlign: 'center', alignSelf: 'flex-start' }}>
+                <footer style={{ padding: '16px', textAlign: 'center', alignSelf: 'flex-start', display: 'flex', justifyContent: 'space-between', width: '100%' }}>
                     <SettingButton clubId={clubId} />
+                    <button
+                        style={{
+                            background: '#e74c3c',
+                            color: COLORS.white,
+                            border: 'none',
+                            borderRadius: '8px',
+                            padding: '10px 20px',
+                            fontWeight: 600,
+                            cursor: 'pointer',
+                            boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
+                            transition: 'background 0.2s, color 0.2s',
+                        }}
+                        onMouseEnter={e => {
+                            e.currentTarget.style.background = '#c0392b';
+                        }}
+                        onMouseLeave={e => {
+                            e.currentTarget.style.background = '#e74c3c';
+                        }}
+                    >
+                        탈퇴
+                    </button>
                 </footer>
             )}
         </nav>

--- a/frontend/src/components/domain/clubs/clubInfoSideMenu.tsx
+++ b/frontend/src/components/domain/clubs/clubInfoSideMenu.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { COLORS } from '@/constants/colors';
 import SettingButton from './settingButton';
+import { leaveClub } from '@/api/myClub';
 
 const menuItems = [
     { label: '정보', path: (clubId: string) => `/clubs/${clubId}` },
@@ -17,8 +18,22 @@ interface ClubInfoSideMenuProps {
 const ClubInfoSideMenu: React.FC<ClubInfoSideMenuProps> = ({ isHost }) => {
     const params = useParams();
     const clubId = params.clubId as string;
-
     const router = useRouter();
+
+    // 탈퇴 이벤트
+    const handleLeaveClub = () => {
+        if (confirm('정말로 클럽을 탈퇴하시겠습니까?')) {
+            // 탈퇴 로직
+            leaveClub(clubId)
+                .then(() => {
+                    alert('클럽을 성공적으로 탈퇴했습니다.');
+                    router.push('/'); // 탈퇴 후 메인 페이지로 이동
+                })
+                .catch(err => {
+                    alert(err instanceof Error ? err.message : '클럽 탈퇴에 실패했습니다.');
+                });
+        }
+    };
 
     if (!clubId) return null;
 
@@ -75,32 +90,38 @@ const ClubInfoSideMenu: React.FC<ClubInfoSideMenuProps> = ({ isHost }) => {
                     </li>
                 ))}
             </ul>
-            {isHost && (
-                <footer style={{ padding: '16px', textAlign: 'center', alignSelf: 'flex-start', display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                    <SettingButton clubId={clubId} />
-                    <button
-                        style={{
-                            background: '#e74c3c',
-                            color: COLORS.white,
-                            border: 'none',
-                            borderRadius: '8px',
-                            padding: '10px 20px',
-                            fontWeight: 600,
-                            cursor: 'pointer',
-                            boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
-                            transition: 'background 0.2s, color 0.2s',
-                        }}
-                        onMouseEnter={e => {
-                            e.currentTarget.style.background = '#c0392b';
-                        }}
-                        onMouseLeave={e => {
-                            e.currentTarget.style.background = '#e74c3c';
-                        }}
-                    >
-                        탈퇴
-                    </button>
-                </footer>
-            )}
+
+            {/* footer */}
+            <footer style={{ padding: '16px', textAlign: 'center', alignSelf: 'flex-start', display: 'flex', justifyContent: 'space-between', width: '100%' }}>
+                {
+                    isHost && (
+                        <SettingButton clubId={clubId} />
+                    )
+                }
+                <button
+                    style={{
+                        background: '#e74c3c',
+                        color: COLORS.white,
+                        border: 'none',
+                        borderRadius: '8px',
+                        padding: '10px 20px',
+                        fontWeight: 600,
+                        cursor: 'pointer',
+                        boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
+                        transition: 'background 0.2s, color 0.2s',
+                    }}
+                    onMouseEnter={e => {
+                        e.currentTarget.style.background = '#c0392b';
+                    }}
+                    onMouseLeave={e => {
+                        e.currentTarget.style.background = '#e74c3c';
+                    }}
+                    onClick={handleLeaveClub}
+                >
+                    탈퇴
+                </button>
+            </footer>
+
         </nav>
     );
 };

--- a/frontend/src/components/domain/clubs/settingButton.tsx
+++ b/frontend/src/components/domain/clubs/settingButton.tsx
@@ -21,6 +21,10 @@ function SettingButton({ clubId }: SettingButtonProps) {
         {
             label: '모임 삭제',
             onClick: () => router.push(`/clubs/${clubId}/settings/delete`)
+        },
+        {
+            label: '초대 링크',
+            onClick: () => router.push(`/clubs/${clubId}/settings/invite`)
         }
     ];
 


### PR DESCRIPTION
## 📢 기능 설명
- 멤버 정보 반환 API 연동
- 모임 멤버 관리 페이지 구성
- 멤버 삭제, 역할 변경 API 연동
- 초대한 멤버 페이지
- 멤버 추가 API 연동
- 가입 신청한 유저 페이지
- 신청 수락/거절 API 연동
- 초대링크 버튼
- 모임 탈퇴 버튼 생성
- 권한에 따라 UI 숨기기
<br>

## 연결된 issue
close #28 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 클럽 멤버 관리 페이지 및 멤버 목록, 멤버 상세 아이템, 멤버 초대용 다중 이메일 입력, 멤버 탭 컴포넌트가 추가되었습니다.
  * 클럽 멤버 초대, 가입 승인/거절, 역할 변경, 멤버 삭제, 멤버 목록 조회 등 다양한 멤버 관리 기능이 제공됩니다.
  * 클럽 정보 사이드 메뉴에 '클럽 탈퇴' 버튼이 추가되어 사용자가 클럽을 탈퇴할 수 있습니다.
  * 설정 버튼에 '초대 링크' 메뉴가 추가되었습니다.

* **버그 수정 및 개선**
  * 클럽 페이지의 레이아웃과 스크롤 동작이 개선되었습니다.
  * 멤버 API 요청 시 인증 쿠키가 포함되어 보다 안전하게 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->