### PR TITLE
[design] 내 모임 목록

### DIFF
--- a/frontend/src/api/myClub.tsx
+++ b/frontend/src/api/myClub.tsx
@@ -5,6 +5,9 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://localhost:8080';
 type MyInfoInClub = components['schemas']['MyInfoInClub'];
 type SimpleClubInfo = components['schemas']['SimpleClubInfo'];
 
+type MyClubList = components['schemas']['MyClubList'];
+type ClubListItem = components['schemas']['ClubListItem'];
+
 /**
  * 모임에서 내 정보 조회
  * @param clubId 모임 ID
@@ -69,3 +72,45 @@ export const leaveClub = async (clubId: string): Promise<void> => {
         throw new Error(data.code + " : " + (data.message || '모임 탈퇴에 실패했습니다.'));
     }
 }
+
+// 내 모임 목록 전체 조회
+export const getMyClubs = async (): Promise<ClubListItem[]> => {
+
+    const response = await fetch(`${API_URL}/api/v1/my-clubs`, {
+        method: 'GET',
+        credentials: 'include', // 쿠키를 포함하여 요청
+    });
+    if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || '모임 목록을 불러오는 데 실패했습니다.');
+    }
+    const result: { data?: MyClubList } = await response.json();
+    return result.data?.clubs || [];
+};
+
+// [클라이언트용] 초대 수락
+export const acceptClubInvitation = async (clubId: number) => {
+    const response = await fetch(`${API_URL}/api/v1/my-clubs/${clubId}/join`, {
+        method: 'PATCH',
+        credentials: 'include',
+    });
+    if (!response.ok) throw new Error('초대 수락에 실패했습니다.');
+};
+
+// [클라이언트용] 초대 거절
+export const rejectClubInvitation = async (clubId: number) => {
+    const response = await fetch(`${API_URL}/api/v1/my-clubs/${clubId}/invitation`, {
+        method: 'DELETE',
+        credentials: 'include',
+    });
+    if (!response.ok) throw new Error('초대 거절에 실패했습니다.');
+};
+
+// [클라이언트용] 가입 신청 취소
+export const cancelClubApplication = async (clubId: number) => {
+    const response = await fetch(`${API_URL}/api/v1/my-clubs/${clubId}/apply`, {
+        method: 'DELETE',
+        credentials: 'include',
+    });
+    if (!response.ok) throw new Error('가입 신청 취소에 실패했습니다.');
+};

--- a/frontend/src/app/clubs-manage/page.tsx
+++ b/frontend/src/app/clubs-manage/page.tsx
@@ -51,12 +51,20 @@ export default function MyClubsPage() {
         <div className="max-w-7xl mx-auto p-4">
             <div className="flex items-center justify-between mb-6">
                 <h1 className="text-3xl font-bold">모임 관리</h1>
-                <Link
-                    href="/members/mypage"
-                    className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300 text-gray-700 text-sm font-medium"
-                >
-                    마이페이지
-                </Link>
+                <div className="flex gap-2">
+                    <Link
+                        href="/clubs/new"
+                        className="px-4 py-2 rounded bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium"
+                    >
+                        모임 생성
+                    </Link>
+                    <Link
+                        href="/members/mypage"
+                        className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300 text-gray-700 text-sm font-medium"
+                    >
+                        마이페이지
+                    </Link>
+                </div>
             </div>
             <section className="flex">
                 <section className="w-full mb-4">

--- a/frontend/src/app/clubs-manage/page.tsx
+++ b/frontend/src/app/clubs-manage/page.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+
+import { useState, useEffect } from 'react';
+import { components } from '@/types/backend/apiV1/schema'
+import LoadingSpinner from '@/components/global/LoadingSpinner'
+import { getMyClubs } from '@/api/myClub';
+import ClubsManagement from '@/components/domain/clubManage/ClubsManagement';
+
+type MyClubList = components['schemas']['MyClubList'];
+type ClubListItem = components['schemas']['ClubListItem'];
+
+export default function MyClubsPage() {
+    const [initialClubs, setInitialClubs] = useState<ClubListItem[]>([]);
+    const [error, setError] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+
+
+    useEffect(() => {
+        const fetchData = async () => {
+            setIsLoading(true);
+            try {
+                // 순차 호출 (병렬도 가능)
+                const initialClubs = await getMyClubs();
+
+                if (!initialClubs) {
+                    throw new Error('모임 목록을 불러오는 데 실패했습니다.');
+                }
+                setInitialClubs(initialClubs);
+            } catch (err) {
+                setError(err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다.');
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchData();
+    }, []);
+
+    // 가드 클로즈 : 로딩 중
+    if (isLoading) return <LoadingSpinner />;
+
+    // 가드 클로즈 : 에러 발생
+    const errorMessage = error;
+    if (errorMessage) {
+        return <div className="text-center py-12">{errorMessage}</div>;
+    }
+
+
+    return (
+        <div className="max-w-7xl mx-auto p-4">
+            <h1 className="text-3xl font-bold mb-6">멤버 관리</h1>
+            <section className="flex" style={{ height: 'calc(90vh - 64px)' }}>
+                <section className="w-4/5">
+                    {/* 클라이언트 컴포넌트에 초기 데이터를 props로 전달 */}
+                    <ClubsManagement initialClubs={initialClubs} />
+                </section>
+            </section>
+        </div>
+    );
+}

--- a/frontend/src/app/clubs-manage/page.tsx
+++ b/frontend/src/app/clubs-manage/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-
 import { useState, useEffect } from 'react';
 import { components } from '@/types/backend/apiV1/schema'
 import LoadingSpinner from '@/components/global/LoadingSpinner'
 import { getMyClubs } from '@/api/myClub';
 import ClubsManagement from '@/components/domain/clubManage/ClubsManagement';
+import Link from 'next/link';
 
 type MyClubList = components['schemas']['MyClubList'];
 type ClubListItem = components['schemas']['ClubListItem'];
@@ -49,9 +49,17 @@ export default function MyClubsPage() {
 
     return (
         <div className="max-w-7xl mx-auto p-4">
-            <h1 className="text-3xl font-bold mb-6">멤버 관리</h1>
-            <section className="flex" style={{ height: 'calc(90vh - 64px)' }}>
-                <section className="w-4/5">
+            <div className="flex items-center justify-between mb-6">
+                <h1 className="text-3xl font-bold">모임 관리</h1>
+                <Link
+                    href="/members/mypage"
+                    className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300 text-gray-700 text-sm font-medium"
+                >
+                    마이페이지
+                </Link>
+            </div>
+            <section className="flex">
+                <section className="w-full mb-4">
                     {/* 클라이언트 컴포넌트에 초기 데이터를 props로 전달 */}
                     <ClubsManagement initialClubs={initialClubs} />
                 </section>

--- a/frontend/src/components/domain/clubManage/ClubCard.tsx
+++ b/frontend/src/components/domain/clubManage/ClubCard.tsx
@@ -19,16 +19,29 @@ export default function ClubCard({ club, onAcceptInvitation, onRejectInvitation,
 
     return (
         <div className="border rounded-lg shadow-md overflow-hidden">
-            <Link href={`/clubs/${club.clubId}`}>
-                <div className="relative h-40 w-full">
-                    <Image src={club.imageUrl || '/default-club.png'} alt={club.clubName!} fill style={{ objectFit: 'cover' }} />
+            {club.myState === 'JOINING' ? (
+                <Link href={`/clubs/${club.clubId}`}>
+                    <div className="relative h-40 w-full">
+                        <Image src={club.imageUrl || '/default-club-image.png'} alt={club.clubName!} fill style={{ objectFit: 'cover' }} />
+                    </div>
+                    <div className="p-4">
+                        <h3 className="font-bold text-lg truncate">{club.clubName}</h3>
+                        <p className="text-sm text-gray-600 truncate">{club.bio}</p>
+                        <span className="text-xs bg-gray-200 px-2 py-1 rounded-full">{club.category}</span>
+                    </div>
+                </Link>
+            ) : (
+                <div>
+                    <div className="relative h-40 w-full">
+                        <Image src={club.imageUrl || '/default-club-image.png'} alt={club.clubName!} fill style={{ objectFit: 'cover' }} />
+                    </div>
+                    <div className="p-4">
+                        <h3 className="font-bold text-lg truncate">{club.clubName}</h3>
+                        <p className="text-sm text-gray-600 truncate">{club.bio}</p>
+                        <span className="text-xs bg-gray-200 px-2 py-1 rounded-full">{club.category}</span>
+                    </div>
                 </div>
-                <div className="p-4">
-                    <h3 className="font-bold text-lg truncate">{club.clubName}</h3>
-                    <p className="text-sm text-gray-600 truncate">{club.bio}</p>
-                    <span className="text-xs bg-gray-200 px-2 py-1 rounded-full">{club.category}</span>
-                </div>
-            </Link>
+            )}
             {/* --- 조건부 버튼 렌더링 --- */}
             <div className="p-4 bg-gray-50 border-t flex justify-end space-x-2">
                 {club.myState === 'INVITED' && (

--- a/frontend/src/components/domain/clubManage/ClubCard.tsx
+++ b/frontend/src/components/domain/clubManage/ClubCard.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { components } from '@/types/backend/apiV1/schema';
+
+type ClubListItem = components['schemas']['ClubListItem'];
+
+interface ClubCardProps {
+    club: ClubListItem;
+    onAcceptInvitation?: (clubId: number) => void;
+    onRejectInvitation?: (clubId: number) => void;
+    onCancelApplication?: (clubId: number) => void;
+}
+
+export default function ClubCard({ club, onAcceptInvitation, onRejectInvitation, onCancelApplication }: ClubCardProps) {
+    const router = useRouter();
+
+    return (
+        <div className="border rounded-lg shadow-md overflow-hidden">
+            <Link href={`/clubs/${club.clubId}`}>
+                <div className="relative h-40 w-full">
+                    <Image src={club.imageUrl || '/default-club.png'} alt={club.clubName!} fill style={{ objectFit: 'cover' }} />
+                </div>
+                <div className="p-4">
+                    <h3 className="font-bold text-lg truncate">{club.clubName}</h3>
+                    <p className="text-sm text-gray-600 truncate">{club.bio}</p>
+                    <span className="text-xs bg-gray-200 px-2 py-1 rounded-full">{club.category}</span>
+                </div>
+            </Link>
+            {/* --- 조건부 버튼 렌더링 --- */}
+            <div className="p-4 bg-gray-50 border-t flex justify-end space-x-2">
+                {club.myState === 'INVITED' && (
+                    <>
+                        <button onClick={() => { onAcceptInvitation?.(club.clubId!) }} className="btn-primary text-sm">수락</button>
+                        <button onClick={() => { onRejectInvitation?.(club.clubId!) }} className="btn-secondary text-sm">거절</button>
+                    </>
+                )}
+                {club.myState === 'APPLYING' && (
+                    <button onClick={() => { onCancelApplication?.(club.clubId!) }} className="btn-danger text-sm">신청 취소</button>
+                )}
+                {club.myState === 'JOINING' && (
+                    <span className="text-sm text-green-600 font-semibold">가입 완료</span>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/domain/clubManage/ClubCard.tsx
+++ b/frontend/src/components/domain/clubManage/ClubCard.tsx
@@ -28,6 +28,9 @@ export default function ClubCard({ club, onAcceptInvitation, onRejectInvitation,
                         <h3 className="font-bold text-lg truncate">{club.clubName}</h3>
                         <p className="text-sm text-gray-600 truncate">{club.bio}</p>
                         <span className="text-xs bg-gray-200 px-2 py-1 rounded-full">{club.category}</span>
+                        <span className="ml-2 text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded-full">
+                            {club.myRole}
+                        </span>
                     </div>
                 </Link>
             ) : (
@@ -39,6 +42,9 @@ export default function ClubCard({ club, onAcceptInvitation, onRejectInvitation,
                         <h3 className="font-bold text-lg truncate">{club.clubName}</h3>
                         <p className="text-sm text-gray-600 truncate">{club.bio}</p>
                         <span className="text-xs bg-gray-200 px-2 py-1 rounded-full">{club.category}</span>
+                        <span className="ml-2 text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded-full">
+                            {club.myRole}
+                        </span>
                     </div>
                 </div>
             )}

--- a/frontend/src/components/domain/clubManage/ClubList.tsx
+++ b/frontend/src/components/domain/clubManage/ClubList.tsx
@@ -1,0 +1,34 @@
+// src/components/domain/my-clubs/ClubList.tsx
+
+import { components } from '@/types/backend/apiV1/schema';
+import ClubCard from "./ClubCard";
+
+type ClubListItem = components['schemas']['ClubListItem'];
+
+interface ClubListProps {
+    clubs: ClubListItem[];
+    state?: 'JOINING' | 'APPLYING' | 'INVITED';
+    onAcceptInvitation?: (clubId: number) => void;
+    onRejectInvitation?: (clubId: number) => void;
+    onCancelApplication?: (clubId: number) => void;
+}
+
+export default function ClubList({ clubs }: ClubListProps) {
+    // 1. 표시할 모임이 없는 경우
+    if (clubs.length === 0) {
+        return (
+            <div className="text-center text-gray-500 py-20">
+                <p>표시할 모임이 없습니다.</p>
+            </div>
+        );
+    }
+
+    // 2. 모임이 있는 경우, 그리드 레이아웃으로 ClubCard를 렌더링
+    return (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {clubs.map(club => (
+                <ClubCard key={club.clubId} club={club} />
+            ))}
+        </div>
+    );
+}

--- a/frontend/src/components/domain/clubManage/ClubList.tsx
+++ b/frontend/src/components/domain/clubManage/ClubList.tsx
@@ -13,7 +13,7 @@ interface ClubListProps {
     onCancelApplication?: (clubId: number) => void;
 }
 
-export default function ClubList({ clubs }: ClubListProps) {
+export default function ClubList({ clubs, state, onAcceptInvitation, onRejectInvitation, onCancelApplication }: ClubListProps) {
     // 1. 표시할 모임이 없는 경우
     if (clubs.length === 0) {
         return (
@@ -27,7 +27,13 @@ export default function ClubList({ clubs }: ClubListProps) {
     return (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {clubs.map(club => (
-                <ClubCard key={club.clubId} club={club} />
+                <ClubCard
+                    key={club.clubId}
+                    club={club}
+                    onAcceptInvitation={onAcceptInvitation}
+                    onRejectInvitation={onRejectInvitation}
+                    onCancelApplication={onCancelApplication}
+                />
             ))}
         </div>
     );

--- a/frontend/src/components/domain/clubManage/ClubStateTabs.tsx
+++ b/frontend/src/components/domain/clubManage/ClubStateTabs.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+
+export default function ClubStateTabs() {
+    // 1. useSearchParams 훅으로 현재 URL의 쿼리 파라미터에 접근
+    const searchParams = useSearchParams();
+    const currentState = searchParams.get('state') || 'JOINING'; // URL에 state가 없으면 'JOINING'을 기본값으로
+
+    // 2. 탭 데이터 배열
+    const tabs = [
+        { state: 'JOINING', label: '가입한 모임' },
+        { state: 'APPLYING', label: '신청한 모임' },
+        { state: 'INVITED', label: '초대받은 모임' },
+    ];
+
+    return (
+        <div className="mb-6 border-b">
+            <nav className="-mb-px flex space-x-6">
+                {tabs.map(tab => (
+                    <Link
+                        key={tab.state}
+                        href={`/clubs-manage?state=${tab.state}`}
+                        // 3. 현재 state와 탭의 state를 비교하여 조건부 스타일링
+                        className={`py-3 px-1 font-medium text-sm whitespace-nowrap ${currentState === tab.state
+                            ? 'border-b-2 border-blue-600 text-blue-600' // 활성 탭 스타일
+                            : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300' // 비활성 탭 스타일
+                            }`}
+                    >
+                        {tab.label}
+                    </Link>
+                ))}
+            </nav>
+        </div>
+    );
+}

--- a/frontend/src/components/domain/clubManage/ClubsManagement.tsx
+++ b/frontend/src/components/domain/clubManage/ClubsManagement.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState, useMemo, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { components } from '@/types/backend/apiV1/schema';
+import ClubStateTabs from './ClubStateTabs';
+import ClubList from './ClubList';
+import { getMyClubs, acceptClubInvitation, rejectClubInvitation, cancelClubApplication } from '@/api/myClub';
+
+
+type ClubListItem = components['schemas']['ClubListItem'];
+
+interface ClubsManagementProps {
+    initialClubs: ClubListItem[];
+}
+
+export default function ClubsManagement({ initialClubs }: ClubsManagementProps) {
+    const [clubs, setClubs] = useState(initialClubs);
+    const searchParams = useSearchParams();
+    const currentState = searchParams.get('state') || 'JOINING';
+
+    // 탭이 변경될 때마다 서버 데이터를 다시 불러오고 싶다면 useEffect 사용
+    useEffect(() => {
+        setClubs(initialClubs);
+    }, [initialClubs]);
+
+    const refreshClubs = async () => {
+        try {
+            const updatedClubs = await getMyClubs();
+            setClubs(updatedClubs);
+        } catch (err) {
+            console.error('모임 목록을 불러오는 데 실패했습니다.', err);
+            throw new Error('모임 목록을 불러오는 데 실패했습니다.');
+        }
+    };
+
+    const filteredClubs = useMemo(() => {
+        return clubs.filter(club => club.myState === currentState);
+    }, [clubs, currentState]);
+
+    const handleAction = async (action: () => Promise<void>) => {
+        try {
+            await action();
+
+            alert('작업이 완료되었습니다.');
+            await refreshClubs();
+        } catch (err) {
+            alert(err instanceof Error ? err.message : '작업에 실패했습니다.');
+        }
+    };
+
+    const handleAcceptInvitation = (clubId: number) => handleAction(() => acceptClubInvitation(clubId));
+    const handleRejectInvitation = (clubId: number) => handleAction(() => rejectClubInvitation(clubId));
+    const handleCancelApplication = (clubId: number) => handleAction(() => cancelClubApplication(clubId));
+
+    return (
+        <>
+            <ClubStateTabs />
+            <ClubList
+                clubs={filteredClubs}
+                state={currentState as 'JOINING' | 'APPLYING' | 'INVITED'}
+                onAcceptInvitation={handleAcceptInvitation}
+                onRejectInvitation={handleRejectInvitation}
+                onCancelApplication={handleCancelApplication}
+            />
+        </>
+    );
+}

--- a/frontend/src/components/domain/clubMembers/MemberList.tsx
+++ b/frontend/src/components/domain/clubMembers/MemberList.tsx
@@ -3,7 +3,6 @@
 import MemberListItem from './MemberListItem';
 import { components } from '@/types/backend/apiV1/schema';
 import MultiEmailInput from './MultiEmailInput';
-import { inviteMembers } from '@/api/clubMember';
 import { useParams } from 'next/navigation';
 
 type MemberInfo = components['schemas']['ClubMemberInfo'];


### PR DESCRIPTION
## 📢 기능 설명
- 내 모임 목록 페이지 생성
- 모임 생성 버튼 구현
- 초대 온 모임 탭
- 초대 수락, 거절 API 연동
- 가입 신청한 모임 탭
- 가입 신청 취소 API 연동
<br>

## 연결된 issue
close #36 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 내 모임 관리 페이지가 추가되어, 사용자가 가입한 모임, 신청한 모임, 초대받은 모임을 한눈에 관리할 수 있습니다.
  * 모임 목록을 상태별로 탭으로 전환하여 확인할 수 있습니다.
  * 각 모임 카드에서 초대 수락/거절, 신청 취소 등 상태에 따라 다양한 액션 버튼이 제공됩니다.
  * 모임 목록이 비어 있을 경우 안내 메시지가 표시됩니다.

* **버그 수정**
  * 사용되지 않는 멤버 초대 함수의 불필요한 import가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->