### PR TITLE
[refactor] 일정에서 참여자의 역할에 따른 버튼 활성화

### DIFF
--- a/frontend/src/api/schedule.ts
+++ b/frontend/src/api/schedule.ts
@@ -37,6 +37,7 @@ export async function getClubSchedules(
   const res = await fetch(url, {
     method: "GET",
     signal,
+    credentials: 'include',
   });
   return handleResponse<components["schemas"]["RsDataListScheduleDto"]>(res);
 }
@@ -49,6 +50,7 @@ export async function getSchedule(
 ): Promise<RsDataScheduleDetailDto> {
   const res = await fetch(`${BASE_URL}/api/v1/schedules/${scheduleId}`, {
     signal,
+    credentials: 'include',
   });
   return handleResponse(res);
 }
@@ -60,6 +62,7 @@ export async function createSchedule(
   const res = await fetch(`${BASE_URL}/api/v1/schedules`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    credentials: 'include',
     body: JSON.stringify(body),
   });
   return handleResponse(res);
@@ -73,6 +76,7 @@ export async function modifySchedule(
   const res = await fetch(`${BASE_URL}/api/v1/schedules/${scheduleId}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
+    credentials: 'include',
     body: JSON.stringify(body),
   });
   return handleResponse(res);
@@ -84,6 +88,7 @@ export async function deleteSchedule(
 ): Promise<components["schemas"]["RsDataVoid"]> {
   const res = await fetch(`${BASE_URL}/api/v1/schedules/${scheduleId}`, {
     method: "DELETE",
+    credentials: 'include',
   });
   return handleResponse(res);
 }
@@ -92,7 +97,7 @@ export async function deleteSchedule(
 export async function getMySchedules(
   query?: { startDate?: string; endDate?: string },
   signal?: AbortSignal
-): Promise<components["schemas"]["RsDataListScheduleDto"]> {
+): Promise<components["schemas"]["RsDataListScheduleWithClubDto"]> {
   let url = `${BASE_URL}/api/v1/schedules/me`;
   if (query) {
     const params = new URLSearchParams();
@@ -104,6 +109,21 @@ export async function getMySchedules(
   const res = await fetch(url, {
     method: "GET",
     signal,
+    credentials: 'include',
   });
   return handleResponse<components["schemas"]["RsDataListScheduleWithClubDto"]>(res);
+}
+
+// 로그인한 사용자의 모임 정보(권한 확인용)
+export async function getMyClubInfoForSchedule(
+  clubId: number
+): Promise<components["schemas"]["RsDataMyInfoInClub"]> {
+  const url = `${BASE_URL}/api/v1/my-clubs/${clubId}`;
+  
+  const res = await fetch(url, {
+    method: "GET",
+    credentials: 'include',
+  });
+  
+  return handleResponse<components["schemas"]["RsDataMyInfoInClub"]>(res);
 }

--- a/frontend/src/app/schedule/page.tsx
+++ b/frontend/src/app/schedule/page.tsx
@@ -7,7 +7,7 @@ import toast from 'react-hot-toast';
 import { EventClickArg, DateSelectArg, DatesSetArg } from '@fullcalendar/core';
 import FullCalendar from '@fullcalendar/react';
 
-import { getClubSchedules } from "@/api/schedule";
+import { getClubSchedules, getMyClubInfoForSchedule } from "@/api/schedule";
 import { useSchedules } from '@/hooks/useSchedules';
 import { extractDateFromISO } from '@/lib/formatDate';
 import Calendar from '@/components/domain/schedule/Calender';
@@ -18,9 +18,8 @@ import '@/lib/fullcalendar.css';
 
 export default function ScheduleListPage() {
   // 파라미터 처리 - 모임 아이디
-  //const parm = useParams();
-  //const clubId = parm.clubId;
-  const clubId = 1;
+  const parm = useParams();
+  const clubId = parm.clubId;
 
   // 캘린더 처리
   const calendarRef = useRef<FullCalendar>(null);
@@ -30,6 +29,9 @@ export default function ScheduleListPage() {
   // 모달 상태 관리
   const [showModal, setShowModal] = useState<boolean>(false);
   const [modalType, setModalType] = useState<'edit' | 'detail' | null>(null);
+
+  // 리드온리 여부
+  const [isReadOnly, setIsReadOnly] = useState<boolean>(true);
 
   // 커스텀 훅 - 일정 dto, 모임의 일정 목록 조회 fetch 넘김
   const { events, fetchSchedules } = useSchedules((params, signal) => 
@@ -46,7 +48,19 @@ export default function ScheduleListPage() {
       const endDate = extractDateFromISO(view.activeEnd.toISOString());
       fetchSchedules({ startDate, endDate });
     }
-  }, []);
+
+    // 유저의 모임 정보 조회
+    getMyClubInfoForSchedule(clubId)
+      .then(res => {
+        if (res.data?.role) {
+          // 모임 일반 참여자는 조회만 가능
+          setIsReadOnly(res.data.role === 'PARTICIPANT');
+        }
+      })
+      .catch(e => {
+        toast.error("모임 정보를 불러오지 못했습니다.");
+      });
+  }, [clubId]);
 
   // 캘린더 날짜가 변경될 때마다(이전, 다음 버튼 등) 일정 목록 API 재호출
   const handleDatesSet = useCallback((arg: DatesSetArg) => {
@@ -57,6 +71,9 @@ export default function ScheduleListPage() {
 
   // Date UI(일) 클릭 시 일정 생성/수정정 모달
   const handleDateSelect = (selectInfo: DateSelectArg) => {
+    if (isReadOnly) return;
+
+    // 모임장, 매니저만 가능
     setModalType('edit');
     setSelectedDateInfo(selectInfo);
     setSelectedScheduleId(null);
@@ -129,6 +146,7 @@ export default function ScheduleListPage() {
             showModal={showModal}
             selectedScheduleId={selectedScheduleId}
             onClose={handleCloseModal}
+            isReadOnly={isReadOnly}
           />
         )}
         {showModal && modalType === 'edit' && (
@@ -137,7 +155,7 @@ export default function ScheduleListPage() {
             clubId={clubId}
             startDate={selectedDateInfo?.startStr}
             endDate={selectedDateInfo?.endStr}
-            selectedScheduleId={selectedScheduleId} // <-- 수정: prop으로 전달
+            selectedScheduleId={selectedScheduleId}
             onClose={handleCloseModal}
           />
         )}


### PR DESCRIPTION
## 📢 기능 설명
- 참여자는 일정 생성/수정 모달 비활성화
- 참여자는 일정 상세 모달의 삭제, 수정 버튼 비활성화

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #58 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 클럽 내 역할에 따라 일정 편집 기능에 읽기 전용(읽기/쓰기 제한) 권한이 적용됩니다.
  * 클럽 ID가 URL에서 동적으로 추출되어 일정 페이지가 클럽별로 작동합니다.

* **버그 수정**
  * 일정 관련 API 요청 시 인증 정보가 포함되어 보다 안정적인 접근이 가능합니다.

* **개선 사항**
  * 일정 목록 조회 시 클럽 정보와 함께 반환되어 더 많은 정보를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->